### PR TITLE
Phase 2A: 5 Interactive Learn Components

### DIFF
--- a/src/components/learn/AnnotatedCode.tsx
+++ b/src/components/learn/AnnotatedCode.tsx
@@ -1,0 +1,593 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import type { CodeContent } from "@/types/content";
+
+interface AnnotatedCodeProps extends CodeContent {
+  accentColor?: string;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Lightweight regex-based tokenizer
+// Returns an array of { type, value } tokens for a single line of code.
+// ────────────────────────────────────────────────────────────────────────────
+type TokenType = "kw" | "str" | "cmt" | "num" | "fn" | "op" | "plain";
+interface Token {
+  type: TokenType;
+  value: string;
+}
+
+const PYTHON_KW = new Set([
+  "False",
+  "None",
+  "True",
+  "and",
+  "as",
+  "assert",
+  "async",
+  "await",
+  "break",
+  "class",
+  "continue",
+  "def",
+  "del",
+  "elif",
+  "else",
+  "except",
+  "finally",
+  "for",
+  "from",
+  "global",
+  "if",
+  "import",
+  "in",
+  "is",
+  "lambda",
+  "nonlocal",
+  "not",
+  "or",
+  "pass",
+  "raise",
+  "return",
+  "try",
+  "while",
+  "with",
+  "yield",
+]);
+const JS_KW = new Set([
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "export",
+  "extends",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "let",
+  "new",
+  "return",
+  "static",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+  "async",
+  "await",
+  "of",
+  "from",
+  "null",
+  "undefined",
+  "true",
+  "false",
+]);
+const SQL_KW = new Set([
+  "SELECT",
+  "FROM",
+  "WHERE",
+  "JOIN",
+  "LEFT",
+  "RIGHT",
+  "INNER",
+  "OUTER",
+  "ON",
+  "AS",
+  "INSERT",
+  "INTO",
+  "VALUES",
+  "UPDATE",
+  "SET",
+  "DELETE",
+  "CREATE",
+  "TABLE",
+  "INDEX",
+  "DROP",
+  "ALTER",
+  "ADD",
+  "COLUMN",
+  "DISTINCT",
+  "ORDER",
+  "BY",
+  "GROUP",
+  "HAVING",
+  "LIMIT",
+  "OFFSET",
+  "COUNT",
+  "SUM",
+  "AVG",
+  "MIN",
+  "MAX",
+  "AND",
+  "OR",
+  "NOT",
+  "IN",
+  "IS",
+  "NULL",
+  "LIKE",
+  "EXISTS",
+  "BETWEEN",
+  "UNION",
+  "ALL",
+  "WITH",
+  "CTE",
+]);
+const BASH_KW = new Set([
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "for",
+  "do",
+  "done",
+  "while",
+  "until",
+  "case",
+  "esac",
+  "function",
+  "return",
+  "export",
+  "echo",
+  "cd",
+  "ls",
+  "mkdir",
+  "rm",
+  "cp",
+  "mv",
+  "cat",
+  "grep",
+  "awk",
+  "sed",
+  "curl",
+  "wget",
+  "git",
+  "docker",
+  "npm",
+  "pip",
+  "python",
+  "python3",
+  "node",
+  "bash",
+  "sh",
+]);
+
+function tokenizeLine(line: string, lang: string): Token[] {
+  const tokens: Token[] = [];
+  let remaining = line;
+
+  // Determine which keywords to use
+  const kwSet =
+    lang === "python"
+      ? PYTHON_KW
+      : lang === "sql"
+        ? SQL_KW
+        : lang === "bash"
+          ? BASH_KW
+          : JS_KW; // js, ts, json default
+
+  while (remaining.length > 0) {
+    // Single-line comments
+    const cmtPrefixes =
+      lang === "sql" ? ["--"] : lang === "bash" ? ["#"] : ["//", "#"];
+    let matchedCmt = false;
+    for (const prefix of cmtPrefixes) {
+      if (remaining.startsWith(prefix)) {
+        tokens.push({ type: "cmt", value: remaining });
+        remaining = "";
+        matchedCmt = true;
+        break;
+      }
+    }
+    if (matchedCmt) break;
+
+    // String literals (", ', `)
+    const strMatch = remaining.match(/^(["'`])((?:[^\\]|\\.)*?)\1/);
+    if (strMatch) {
+      tokens.push({ type: "str", value: strMatch[0] });
+      remaining = remaining.slice(strMatch[0].length);
+      continue;
+    }
+
+    // Numbers
+    const numMatch = remaining.match(/^-?\d+(\.\d+)?([eE][+-]?\d+)?/);
+    if (numMatch) {
+      tokens.push({ type: "num", value: numMatch[0] });
+      remaining = remaining.slice(numMatch[0].length);
+      continue;
+    }
+
+    // Identifiers / keywords
+    const wordMatch = remaining.match(/^[a-zA-Z_]\w*/);
+    if (wordMatch) {
+      const word = wordMatch[0];
+      const isKw =
+        lang === "sql" ? kwSet.has(word.toUpperCase()) : kwSet.has(word);
+      // Function call detection: word followed by (
+      const isFn =
+        !isKw &&
+        remaining.length > word.length &&
+        remaining[word.length] === "(";
+      tokens.push({
+        type: isKw ? "kw" : isFn ? "fn" : "plain",
+        value: word,
+      });
+      remaining = remaining.slice(word.length);
+      continue;
+    }
+
+    // Operators / punctuation
+    const opMatch = remaining.match(/^[+\-*/%=<>!&|^~?:,;.()\[\]{}@]+/);
+    if (opMatch) {
+      tokens.push({ type: "op", value: opMatch[0] });
+      remaining = remaining.slice(opMatch[0].length);
+      continue;
+    }
+
+    // Whitespace
+    const wsMatch = remaining.match(/^\s+/);
+    if (wsMatch) {
+      tokens.push({ type: "plain", value: wsMatch[0] });
+      remaining = remaining.slice(wsMatch[0].length);
+      continue;
+    }
+
+    // Fallback: consume one char
+    tokens.push({ type: "plain", value: remaining[0] });
+    remaining = remaining.slice(1);
+  }
+
+  return tokens;
+}
+
+const TOKEN_COLORS: Record<TokenType, string> = {
+  kw: "#c792ea", // purple — keywords
+  str: "#c3e88d", // green  — strings
+  cmt: "#546e7a", // grey   — comments
+  num: "#f78c6c", // orange — numbers
+  fn: "#82aaff", // blue   — function calls
+  op: "#89ddff", // cyan   — operators
+  plain: "#e2e8f0", // white  — default
+};
+
+function renderLine(line: string, lang: string) {
+  const tokens = tokenizeLine(line, lang);
+  return tokens.map((tok, i) => (
+    <span key={i} style={{ color: TOKEN_COLORS[tok.type] }}>
+      {tok.value}
+    </span>
+  ));
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Component
+// ────────────────────────────────────────────────────────────────────────────
+export default function AnnotatedCode({
+  language,
+  title,
+  code,
+  annotations = [],
+  accentColor = "#3b82f6",
+}: AnnotatedCodeProps) {
+  const [activeAnnotation, setActiveAnnotation] = useState<number | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const lines = code.split("\n");
+
+  // Build a map: lineNumber (1-indexed) → annotation index list
+  const lineToAnnotations: Record<number, number[]> = {};
+  annotations.forEach((ann, idx) => {
+    ann.lines.forEach((ln) => {
+      if (!lineToAnnotations[ln]) lineToAnnotations[ln] = [];
+      lineToAnnotations[ln].push(idx);
+    });
+  });
+
+  // Lines highlighted by the active annotation
+  const highlightedLines = new Set<number>(
+    activeAnnotation !== null
+      ? (annotations[activeAnnotation]?.lines ?? [])
+      : [],
+  );
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // ignore
+    }
+  }, [code]);
+
+  const handleAnnotationClick = (idx: number) => {
+    setActiveAnnotation((prev) => (prev === idx ? null : idx));
+  };
+
+  const handlePrev = () => {
+    setActiveAnnotation((prev) =>
+      prev === null || prev === 0 ? annotations.length - 1 : prev - 1,
+    );
+  };
+
+  const handleNext = () => {
+    setActiveAnnotation((prev) =>
+      prev === null || prev === annotations.length - 1 ? 0 : prev + 1,
+    );
+  };
+
+  const accentRgb = accentColor.startsWith("#")
+    ? hexToRgb(accentColor)
+    : "59,130,246";
+
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ border: "1px solid rgba(255,255,255,0.08)" }}
+    >
+      {/* Header bar */}
+      <div
+        className="flex items-center justify-between px-4 py-2.5"
+        style={{
+          backgroundColor: "rgba(255,255,255,0.04)",
+          borderBottom: "1px solid rgba(255,255,255,0.06)",
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            className="text-xs font-mono px-2 py-0.5 rounded"
+            style={{
+              backgroundColor: "rgba(255,255,255,0.06)",
+              color: "var(--text-muted)",
+            }}
+          >
+            {language}
+          </span>
+          {title && (
+            <span
+              className="text-sm font-medium"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              {title}
+            </span>
+          )}
+        </div>
+        <button
+          onClick={handleCopy}
+          className="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded transition-colors cursor-pointer"
+          style={{
+            color: copied ? "#c3e88d" : "var(--text-muted)",
+            backgroundColor: "rgba(255,255,255,0.04)",
+            border: "1px solid rgba(255,255,255,0.08)",
+          }}
+          aria-label="Copy code to clipboard"
+        >
+          {copied ? (
+            <>
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+              Copied
+            </>
+          ) : (
+            <>
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <rect x="9" y="9" width="13" height="13" rx="2" />
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+              </svg>
+              Copy
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Code area */}
+      <div
+        className="overflow-x-auto"
+        style={{ backgroundColor: "var(--code-bg)" }}
+      >
+        <table
+          className="w-full border-collapse text-[0.8125rem] leading-6"
+          style={{ fontFamily: "var(--font-mono), monospace" }}
+        >
+          <tbody>
+            {lines.map((line, i) => {
+              const lineNum = i + 1;
+              const annIdxs = lineToAnnotations[lineNum] ?? [];
+              const isHighlighted = highlightedLines.has(lineNum);
+
+              return (
+                <tr
+                  key={lineNum}
+                  style={{
+                    backgroundColor: isHighlighted
+                      ? `rgba(${accentRgb}, 0.12)`
+                      : "transparent",
+                    transition: "background-color 150ms",
+                  }}
+                >
+                  {/* Line number gutter */}
+                  <td
+                    className="select-none text-right pr-4 pl-4 w-8"
+                    style={{
+                      color: isHighlighted ? accentColor : "var(--text-muted)",
+                      borderRight: "1px solid rgba(255,255,255,0.06)",
+                      userSelect: "none",
+                    }}
+                  >
+                    {lineNum}
+                  </td>
+
+                  {/* Annotation marker column */}
+                  <td
+                    className="w-6 px-1 text-center"
+                    style={{ verticalAlign: "middle" }}
+                  >
+                    {annIdxs.map((idx) => (
+                      <button
+                        key={idx}
+                        onClick={() => handleAnnotationClick(idx)}
+                        className="inline-flex items-center justify-center rounded-full text-[10px] font-bold cursor-pointer transition-transform hover:scale-110"
+                        style={{
+                          width: 18,
+                          height: 18,
+                          backgroundColor:
+                            activeAnnotation === idx
+                              ? accentColor
+                              : `rgba(${accentRgb}, 0.25)`,
+                          color:
+                            activeAnnotation === idx ? "#fff" : accentColor,
+                          border: `1px solid ${accentColor}`,
+                          lineHeight: 1,
+                        }}
+                        aria-label={`Annotation ${idx + 1}`}
+                      >
+                        {idx + 1}
+                      </button>
+                    ))}
+                  </td>
+
+                  {/* Code content */}
+                  <td className="py-0.5 pl-2 pr-6 whitespace-pre">
+                    {line === "" ? "\u00A0" : renderLine(line, language)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Annotation explanation panel */}
+      {activeAnnotation !== null && annotations[activeAnnotation] && (
+        <div
+          className="px-4 py-3 text-sm"
+          style={{
+            backgroundColor: `rgba(${accentRgb}, 0.08)`,
+            borderTop: `1px solid rgba(${accentRgb}, 0.2)`,
+            color: "var(--text-secondary)",
+          }}
+        >
+          <div className="flex items-start gap-2">
+            <span
+              className="inline-flex items-center justify-center rounded-full text-[10px] font-bold shrink-0 mt-0.5"
+              style={{
+                width: 18,
+                height: 18,
+                backgroundColor: accentColor,
+                color: "#fff",
+              }}
+            >
+              {activeAnnotation + 1}
+            </span>
+            <p className="leading-relaxed">
+              {annotations[activeAnnotation].text}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Auto-walk controls */}
+      {annotations.length > 1 && (
+        <div
+          className="flex items-center justify-between px-4 py-2"
+          style={{
+            borderTop: "1px solid rgba(255,255,255,0.06)",
+            backgroundColor: "rgba(255,255,255,0.02)",
+          }}
+        >
+          <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+            {activeAnnotation !== null
+              ? `Annotation ${activeAnnotation + 1} of ${annotations.length}`
+              : `${annotations.length} annotations`}
+          </span>
+          <div className="flex gap-2">
+            <button
+              onClick={handlePrev}
+              className="text-xs px-2.5 py-1 rounded cursor-pointer transition-colors"
+              style={{
+                backgroundColor: "rgba(255,255,255,0.05)",
+                color: "var(--text-secondary)",
+                border: "1px solid rgba(255,255,255,0.1)",
+              }}
+              aria-label="Previous annotation"
+            >
+              ← Prev
+            </button>
+            <button
+              onClick={handleNext}
+              className="text-xs px-2.5 py-1 rounded cursor-pointer transition-colors"
+              style={{
+                backgroundColor: "rgba(255,255,255,0.05)",
+                color: "var(--text-secondary)",
+                border: "1px solid rgba(255,255,255,0.1)",
+              }}
+              aria-label="Next annotation"
+            >
+              Next →
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function hexToRgb(hex: string): string {
+  const clean = hex.replace("#", "");
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  return `${r},${g},${b}`;
+}

--- a/src/components/learn/BeforeAfter.tsx
+++ b/src/components/learn/BeforeAfter.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import type { ComparisonContent } from "@/types/content";
+import MarkdownText from "./MarkdownText";
+
+interface BeforeAfterProps extends ComparisonContent {
+  accentColor?: string;
+}
+
+type Tab = "before" | "after";
+
+export default function BeforeAfter({
+  before,
+  after,
+  accentColor = "#3b82f6",
+}: BeforeAfterProps) {
+  const [activeTab, setActiveTab] = useState<Tab>("before");
+  const [visible, setVisible] = useState(true);
+  const prevTab = useRef<Tab>("before");
+
+  // Crossfade: fade out → switch content → fade in
+  const handleTabClick = (tab: Tab) => {
+    if (tab === activeTab) return;
+    setVisible(false);
+    setTimeout(() => {
+      setActiveTab(tab);
+      prevTab.current = tab;
+      setVisible(true);
+    }, 120); // matches 150ms transition — start fading in at 120ms
+  };
+
+  // Keyboard: Tab navigates between tabs, Enter activates
+  const handleKeyDown = (e: React.KeyboardEvent, tab: Tab) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleTabClick(tab);
+    }
+  };
+
+  const currentContent = activeTab === "before" ? before : after;
+
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ border: "1px solid rgba(255,255,255,0.08)" }}
+    >
+      {/* Tab bar */}
+      <div
+        className="flex"
+        role="tablist"
+        aria-label="Before and after comparison"
+        style={{ borderBottom: "1px solid rgba(255,255,255,0.08)" }}
+      >
+        {/* Before tab */}
+        <button
+          role="tab"
+          aria-selected={activeTab === "before"}
+          aria-controls="before-after-panel"
+          onClick={() => handleTabClick("before")}
+          onKeyDown={(e) => handleKeyDown(e, "before")}
+          className="relative flex-1 flex items-center justify-center gap-2 px-5 py-3 text-sm font-medium transition-colors cursor-pointer"
+          style={{
+            backgroundColor:
+              activeTab === "before"
+                ? "rgba(239,68,68,0.08)"
+                : "rgba(255,255,255,0.02)",
+            color: activeTab === "before" ? "#ef4444" : "var(--text-muted)",
+            borderRight: "1px solid rgba(255,255,255,0.06)",
+          }}
+        >
+          {/* Before icon: X circle */}
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="15" y1="9" x2="9" y2="15" />
+            <line x1="9" y1="9" x2="15" y2="15" />
+          </svg>
+          {before.label}
+          {/* Active underline */}
+          {activeTab === "before" && (
+            <span
+              className="absolute bottom-0 left-0 right-0 h-0.5"
+              style={{ backgroundColor: "#ef4444" }}
+            />
+          )}
+        </button>
+
+        {/* After tab */}
+        <button
+          role="tab"
+          aria-selected={activeTab === "after"}
+          aria-controls="before-after-panel"
+          onClick={() => handleTabClick("after")}
+          onKeyDown={(e) => handleKeyDown(e, "after")}
+          className="relative flex-1 flex items-center justify-center gap-2 px-5 py-3 text-sm font-medium transition-colors cursor-pointer"
+          style={{
+            backgroundColor:
+              activeTab === "after"
+                ? "rgba(16,185,129,0.08)"
+                : "rgba(255,255,255,0.02)",
+            color: activeTab === "after" ? "#10b981" : "var(--text-muted)",
+          }}
+        >
+          {/* After icon: check circle */}
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <polyline points="8 12 11 15 16 9" />
+          </svg>
+          {after.label}
+          {/* Active underline */}
+          {activeTab === "after" && (
+            <span
+              className="absolute bottom-0 left-0 right-0 h-0.5"
+              style={{ backgroundColor: "#10b981" }}
+            />
+          )}
+        </button>
+      </div>
+
+      {/* Content area */}
+      <div
+        id="before-after-panel"
+        role="tabpanel"
+        className="p-5"
+        style={{
+          opacity: visible ? 1 : 0,
+          transition: "opacity 150ms ease",
+          backgroundColor:
+            activeTab === "before"
+              ? "rgba(239,68,68,0.03)"
+              : "rgba(16,185,129,0.03)",
+          minHeight: 80,
+        }}
+        aria-label={currentContent.label}
+      >
+        {/* Tab label badge */}
+        <div className="flex items-center gap-2 mb-3">
+          <span
+            className="text-xs font-semibold px-2 py-0.5 rounded"
+            style={{
+              backgroundColor:
+                activeTab === "before"
+                  ? "rgba(239,68,68,0.15)"
+                  : "rgba(16,185,129,0.15)",
+              color: activeTab === "before" ? "#ef4444" : "#10b981",
+            }}
+          >
+            {currentContent.label}
+          </span>
+        </div>
+
+        <MarkdownText content={currentContent.content} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/learn/LearnPanel.tsx
+++ b/src/components/learn/LearnPanel.tsx
@@ -1,7 +1,20 @@
-import type { LearnSection, SectionType } from "@/types/content";
+import type {
+  LearnSection,
+  SectionType,
+  CodeContent,
+  DiagramContent,
+  ComparisonContent,
+  StepsContent,
+  PlaygroundContent,
+} from "@/types/content";
 import MarkdownText from "./MarkdownText";
 import CalloutBox from "./CalloutBox";
 import PlaceholderSection from "./PlaceholderSection";
+import AnnotatedCode from "./AnnotatedCode";
+import PipelineDiagram from "./PipelineDiagram";
+import BeforeAfter from "./BeforeAfter";
+import StepReveal from "./StepReveal";
+import SliderPlayground from "./SliderPlayground";
 
 interface LearnPanelProps {
   learnSections: LearnSection[];
@@ -10,7 +23,13 @@ interface LearnPanelProps {
 }
 
 // Render a single section based on its type
-function SectionRenderer({ section }: { section: LearnSection }) {
+function SectionRenderer({
+  section,
+  accentColor,
+}: {
+  section: LearnSection;
+  accentColor?: string;
+}) {
   const { sectionType, content, title } = section;
   const type = sectionType as SectionType;
 
@@ -47,19 +66,66 @@ function SectionRenderer({ section }: { section: LearnSection }) {
       );
     }
 
-    // Placeholders for Phase 2 interactive components
-    case "code":
-    case "diagram":
-    case "comparison":
-    case "steps":
-    case "playground":
+    case "code": {
+      const codeContent = content as CodeContent;
       return (
-        <PlaceholderSection
-          sectionType={type}
-          title={title}
-          content={content}
+        <AnnotatedCode
+          language={codeContent.language ?? "python"}
+          title={codeContent.title ?? title ?? undefined}
+          code={codeContent.code ?? ""}
+          annotations={codeContent.annotations ?? []}
+          accentColor={accentColor}
         />
       );
+    }
+
+    case "diagram": {
+      const diagramContent = content as DiagramContent;
+      return (
+        <PipelineDiagram
+          nodes={diagramContent.nodes ?? []}
+          edges={diagramContent.edges ?? []}
+          animate={diagramContent.animate ?? true}
+          stepThrough={diagramContent.stepThrough ?? false}
+          accentColor={accentColor}
+        />
+      );
+    }
+
+    case "comparison": {
+      const compContent = content as ComparisonContent;
+      return (
+        <BeforeAfter
+          before={compContent.before}
+          after={compContent.after}
+          accentColor={accentColor}
+        />
+      );
+    }
+
+    case "steps": {
+      const stepsContent = content as StepsContent;
+      return (
+        <StepReveal
+          steps={stepsContent.steps ?? []}
+          accentColor={accentColor}
+        />
+      );
+    }
+
+    case "playground": {
+      const playContent = content as PlaygroundContent;
+      return (
+        <SliderPlayground
+          title={playContent.title ?? title ?? "Interactive Playground"}
+          sliders={playContent.sliders ?? []}
+          renderType={playContent.renderType ?? "chunkPreview"}
+          sampleText={playContent.sampleText}
+          customRenderer={playContent.customRenderer}
+          accentColor={accentColor}
+        />
+      );
+    }
 
     default:
       return (
@@ -110,7 +176,7 @@ export default function LearnPanel({
                   }}
                 />
               )}
-              <SectionRenderer section={section} />
+              <SectionRenderer section={section} accentColor={accentColor} />
             </div>
           ))}
       </div>

--- a/src/components/learn/PipelineDiagram.tsx
+++ b/src/components/learn/PipelineDiagram.tsx
@@ -1,0 +1,518 @@
+"use client";
+
+import { useState, useCallback, useEffect, useRef } from "react";
+import type { DiagramContent } from "@/types/content";
+
+// Node dimensions
+const NODE_W = 160;
+const NODE_H = 60;
+const H_GAP = 80; // horizontal gap between nodes
+const PADDING = 32; // canvas padding
+
+// Simple icon paths (inline SVG, no external lib)
+const ICON_PATHS: Record<string, string> = {
+  search: "M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm4.24-1.76 3.5 3.5",
+  cube: "M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5",
+  database:
+    "M12 3C7 3 3 4.8 3 7s4 4 9 4 9-1.8 9-4-4-4-9-4zM3 7v5c0 2.2 4 4 9 4s9-1.8 9-4V7M3 12v5c0 2.2 4 4 9 4s9-1.8 9-4v-5",
+  sparkles:
+    "M12 3v1m0 16v1M4.22 4.22l.7.7m12.16 12.16.7.7M3 12h1m16 0h1M4.92 19.08l.7-.7M18.36 5.64l.7-.7M12 7a5 5 0 1 1 0 10A5 5 0 0 1 12 7z",
+  cpu: "M9 3H5a2 2 0 0 0-2 2v4m6-6h6m-6 0v18m6-18h4a2 2 0 0 1 2 2v4m-6-6v18m0 0H9m6 0h4a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2m0 0V9M5 9h14M5 9V5",
+  arrow: "M5 12h14M12 5l7 7-7 7",
+  layers: "M12 2L2 7l10 5 10-5-10-5zM2 12l10 5 10-5M2 17l10 5 10-5",
+  eye: "M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8zm11-3a3 3 0 1 0 0 6 3 3 0 0 0 0-6z",
+  zap: "M13 2L3 14h9l-1 8 10-12h-9l1-8z",
+  settings:
+    "M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.07-1.07 1.42 1.42-1.42 1.42-1.42-1.42a7 7 0 0 1-3.65 1.07v2h-2v-2a7 7 0 0 1-3.65-1.07L6.93 16.35 5.51 14.93l1.42-1.42A7 7 0 0 1 6 9.07V7h2V9.07a7 7 0 0 1 3.07-1.07V6h2v2a7 7 0 0 1 3.07 1.07l1.42-1.42z",
+  filter: "M22 3H2l8 9.46V19l4 2v-8.54L22 3z",
+  check: "M20 6L9 17l-5-5",
+  file: "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm0 0v6h6",
+  code: "M16 18l6-6-6-6M8 6l-6 6 6 6",
+  terminal: "M4 17l6-6-6-6m6 14h8",
+  network: "M9 3H5l-2 9h14L15 3H11m-2 0v9m4-9v9",
+  brain:
+    "M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96-.46 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 1.98-3A2.5 2.5 0 0 1 9.5 2zm5 0A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96-.46 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-1.98-3A2.5 2.5 0 0 0 14.5 2z",
+};
+
+function DiagramIcon({ name, size = 16 }: { name: string; size?: number }) {
+  const d = ICON_PATHS[name] ?? ICON_PATHS.sparkles;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {d
+        .split("M")
+        .filter(Boolean)
+        .map((seg, i) => (
+          <path key={i} d={`M${seg}`} />
+        ))}
+    </svg>
+  );
+}
+
+// Compute topological order of node IDs
+function topoSort(nodeIds: string[], edges: Array<[string, string]>): string[] {
+  const inDegree: Record<string, number> = {};
+  const adj: Record<string, string[]> = {};
+  for (const id of nodeIds) {
+    inDegree[id] = 0;
+    adj[id] = [];
+  }
+  for (const [from, to] of edges) {
+    adj[from]?.push(to);
+    if (inDegree[to] !== undefined) inDegree[to]++;
+  }
+  const queue = nodeIds.filter((id) => inDegree[id] === 0);
+  const result: string[] = [];
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    result.push(cur);
+    for (const next of adj[cur] ?? []) {
+      inDegree[next]--;
+      if (inDegree[next] === 0) queue.push(next);
+    }
+  }
+  // Append any not reached (cycles)
+  for (const id of nodeIds) {
+    if (!result.includes(id)) result.push(id);
+  }
+  return result;
+}
+
+interface PipelineDiagramProps extends DiagramContent {
+  accentColor?: string;
+}
+
+export default function PipelineDiagram({
+  nodes,
+  edges,
+  animate,
+  stepThrough = false,
+  accentColor = "#3b82f6",
+}: PipelineDiagramProps) {
+  const [activeNode, setActiveNode] = useState<string | null>(null);
+  const [step, setStep] = useState<number>(-1); // -1 = not started
+  const [tooltipNode, setTooltipNode] = useState<string | null>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const orderedIds = topoSort(
+    nodes.map((n) => n.id),
+    edges,
+  );
+  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+
+  // Assign x positions based on topological order
+  const nodePositions: Record<string, { x: number; y: number }> = {};
+  orderedIds.forEach((id, i) => {
+    nodePositions[id] = {
+      x: PADDING + i * (NODE_W + H_GAP),
+      y: PADDING,
+    };
+  });
+
+  const svgWidth =
+    PADDING + orderedIds.length * (NODE_W + H_GAP) - H_GAP + PADDING;
+  const svgHeight = NODE_H + PADDING * 2 + 40; // +40 for tooltip area
+
+  // Determine which nodes are "active" (visited) in step-through mode
+  const visitedIds = new Set<string>();
+  if (step >= 0) {
+    for (let i = 0; i <= step; i++) {
+      visitedIds.add(orderedIds[i]);
+    }
+  }
+  const currentId = step >= 0 ? orderedIds[step] : null;
+
+  // Edge active check: edge is active if both endpoints are visited and the edge leads TO current
+  function isEdgeActive(from: string, to: string) {
+    if (!stepThrough || step < 0) return animate;
+    return visitedIds.has(from) && visitedIds.has(to);
+  }
+
+  function isEdgeCurrent(from: string, to: string) {
+    if (!stepThrough || step < 0) return false;
+    return visitedIds.has(from) && to === currentId;
+  }
+
+  const handleNodeClick = (id: string) => {
+    setTooltipNode((prev) => (prev === id ? null : id));
+    if (!stepThrough) setActiveNode((prev) => (prev === id ? null : id));
+  };
+
+  const handleNext = () => {
+    setStep((prev) => {
+      const next = prev + 1;
+      if (next >= orderedIds.length) return prev;
+      setTooltipNode(orderedIds[next]);
+      return next;
+    });
+  };
+
+  const handlePrev = () => {
+    setStep((prev) => {
+      if (prev <= 0) return prev;
+      const next = prev - 1;
+      setTooltipNode(orderedIds[next]);
+      return next;
+    });
+  };
+
+  const handleReset = () => {
+    setStep(-1);
+    setTooltipNode(null);
+    setActiveNode(null);
+  };
+
+  // Keyboard navigation for step-through
+  useEffect(() => {
+    if (!stepThrough) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        handleNext();
+      }
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        handlePrev();
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        handleReset();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  });
+
+  const tooltipNodeData = tooltipNode ? nodeMap.get(tooltipNode) : null;
+
+  // Build edge path: straight line with slight curve if parallel
+  function edgePath(from: string, to: string) {
+    const p1 = nodePositions[from];
+    const p2 = nodePositions[to];
+    if (!p1 || !p2) return "";
+    const x1 = p1.x + NODE_W;
+    const y1 = p1.y + NODE_H / 2;
+    const x2 = p2.x;
+    const y2 = p2.y + NODE_H / 2;
+    const mx = (x1 + x2) / 2;
+    return `M ${x1} ${y1} C ${mx} ${y1} ${mx} ${y2} ${x2} ${y2}`;
+  }
+
+  const accentRgb = hexToRgb(accentColor);
+
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ border: "1px solid rgba(255,255,255,0.08)" }}
+    >
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-4 py-2.5"
+        style={{
+          backgroundColor: "rgba(255,255,255,0.03)",
+          borderBottom: "1px solid rgba(255,255,255,0.06)",
+        }}
+      >
+        <span
+          className="text-xs font-semibold uppercase tracking-widest"
+          style={{ color: "var(--text-muted)" }}
+        >
+          Pipeline Diagram
+        </span>
+        {stepThrough && (
+          <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+            {step < 0
+              ? "Press Next to start"
+              : `Step ${step + 1} of ${orderedIds.length}`}
+          </span>
+        )}
+      </div>
+
+      {/* SVG canvas */}
+      <div
+        className="w-full overflow-x-auto"
+        style={{ backgroundColor: "var(--code-bg)" }}
+      >
+        <svg
+          ref={svgRef}
+          width={svgWidth}
+          height={svgHeight}
+          viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+          style={{ minWidth: svgWidth, display: "block" }}
+          role="img"
+          aria-label="Pipeline diagram"
+        >
+          {/* Arrow marker definition */}
+          <defs>
+            <marker
+              id="arrow"
+              markerWidth="8"
+              markerHeight="8"
+              refX="6"
+              refY="3"
+              orient="auto"
+            >
+              <path d="M0,0 L8,3 L0,6 Z" fill="rgba(255,255,255,0.25)" />
+            </marker>
+            <marker
+              id="arrow-active"
+              markerWidth="8"
+              markerHeight="8"
+              refX="6"
+              refY="3"
+              orient="auto"
+            >
+              <path d="M0,0 L8,3 L0,6 Z" fill={accentColor} />
+            </marker>
+          </defs>
+
+          {/* Edges */}
+          {edges.map(([from, to]) => {
+            const active = isEdgeActive(from, to);
+            const isCurrent = isEdgeCurrent(from, to);
+            const d = edgePath(from, to);
+            return (
+              <path
+                key={`${from}-${to}`}
+                d={d}
+                fill="none"
+                stroke={
+                  isCurrent
+                    ? accentColor
+                    : active
+                      ? accentColor
+                      : "rgba(255,255,255,0.2)"
+                }
+                strokeWidth={isCurrent ? 2 : 1.5}
+                strokeDasharray={active ? "8 12" : undefined}
+                strokeOpacity={active ? 1 : 0.6}
+                markerEnd={isCurrent ? "url(#arrow-active)" : "url(#arrow)"}
+                className={active ? "edge-path" : undefined}
+                style={
+                  active
+                    ? { animation: "flowPulse 1s linear infinite" }
+                    : undefined
+                }
+              />
+            );
+          })}
+
+          {/* Nodes */}
+          {nodes.map((node) => {
+            const pos = nodePositions[node.id];
+            if (!pos) return null;
+            const isActive = activeNode === node.id || currentId === node.id;
+            const isVisited = visitedIds.has(node.id);
+            const isDimmed = stepThrough && step >= 0 && !isVisited;
+            const isTooltipOpen = tooltipNode === node.id;
+
+            return (
+              <g
+                key={node.id}
+                onClick={() => handleNodeClick(node.id)}
+                style={{ cursor: "pointer" }}
+                role="button"
+                tabIndex={0}
+                aria-label={`${node.label}: ${node.description}`}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ")
+                    handleNodeClick(node.id);
+                }}
+              >
+                {/* Node glow effect */}
+                {isActive && (
+                  <rect
+                    x={pos.x - 4}
+                    y={pos.y - 4}
+                    width={NODE_W + 8}
+                    height={NODE_H + 8}
+                    rx="14"
+                    fill="none"
+                    stroke={accentColor}
+                    strokeWidth="1.5"
+                    strokeOpacity="0.4"
+                    filter={`drop-shadow(0 0 10px ${accentColor})`}
+                  />
+                )}
+
+                {/* Node rectangle */}
+                <rect
+                  x={pos.x}
+                  y={pos.y}
+                  width={NODE_W}
+                  height={NODE_H}
+                  rx="10"
+                  fill={
+                    isActive
+                      ? `rgba(${accentRgb}, 0.18)`
+                      : isVisited && stepThrough
+                        ? `rgba(${accentRgb}, 0.08)`
+                        : "rgba(255,255,255,0.05)"
+                  }
+                  stroke={
+                    isActive
+                      ? accentColor
+                      : isTooltipOpen
+                        ? accentColor
+                        : "rgba(255,255,255,0.12)"
+                  }
+                  strokeWidth={isActive ? 1.5 : 1}
+                  opacity={isDimmed ? 0.35 : 1}
+                  style={{ transition: "all 200ms" }}
+                />
+
+                {/* Icon + Label */}
+                <foreignObject
+                  x={pos.x}
+                  y={pos.y}
+                  width={NODE_W}
+                  height={NODE_H}
+                  style={{
+                    opacity: isDimmed ? 0.35 : 1,
+                    transition: "opacity 200ms",
+                  }}
+                >
+                  <div
+                    style={{
+                      width: NODE_W,
+                      height: NODE_H,
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      gap: 4,
+                    }}
+                  >
+                    <span
+                      style={{
+                        color: isActive ? accentColor : "var(--text-muted)",
+                      }}
+                    >
+                      <DiagramIcon name={node.icon} size={14} />
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 12,
+                        fontWeight: 500,
+                        color: isActive
+                          ? "var(--text-primary)"
+                          : "var(--text-secondary)",
+                        textAlign: "center",
+                        padding: "0 8px",
+                        lineHeight: 1.3,
+                        transition: "color 200ms",
+                      }}
+                    >
+                      {node.label}
+                    </span>
+                  </div>
+                </foreignObject>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      {/* Tooltip / description panel */}
+      {tooltipNodeData && (
+        <div
+          className="px-4 py-3 text-sm"
+          style={{
+            backgroundColor: `rgba(${accentRgb}, 0.07)`,
+            borderTop: `1px solid rgba(${accentRgb}, 0.18)`,
+            color: "var(--text-secondary)",
+          }}
+        >
+          <div className="flex items-start gap-2">
+            <span style={{ color: accentColor, marginTop: 2 }}>
+              <DiagramIcon name={tooltipNodeData.icon} size={14} />
+            </span>
+            <div>
+              <p
+                className="font-medium text-sm mb-0.5"
+                style={{ color: "var(--text-primary)" }}
+              >
+                {tooltipNodeData.label}
+              </p>
+              <p style={{ color: "var(--text-secondary)" }}>
+                {tooltipNodeData.description}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Step-through controls */}
+      {stepThrough && (
+        <div
+          className="flex items-center justify-between px-4 py-2.5"
+          style={{
+            borderTop: "1px solid rgba(255,255,255,0.06)",
+            backgroundColor: "rgba(255,255,255,0.02)",
+          }}
+        >
+          <button
+            onClick={handleReset}
+            className="text-xs px-2.5 py-1 rounded cursor-pointer"
+            style={{
+              color: "var(--text-muted)",
+              border: "1px solid rgba(255,255,255,0.08)",
+            }}
+          >
+            Reset
+          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={handlePrev}
+              disabled={step <= 0}
+              className="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
+              style={{
+                backgroundColor: "rgba(255,255,255,0.05)",
+                color: "var(--text-secondary)",
+                border: "1px solid rgba(255,255,255,0.1)",
+              }}
+              aria-label="Previous step"
+            >
+              ← Prev
+            </button>
+            <button
+              onClick={handleNext}
+              disabled={step >= orderedIds.length - 1}
+              className="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
+              style={{
+                backgroundColor:
+                  step < 0 ? accentColor : "rgba(255,255,255,0.05)",
+                color: step < 0 ? "#fff" : "var(--text-secondary)",
+                border: `1px solid ${step < 0 ? accentColor : "rgba(255,255,255,0.1)"}`,
+              }}
+              aria-label="Next step"
+            >
+              {step < 0
+                ? "Start →"
+                : step >= orderedIds.length - 1
+                  ? "Done ✓"
+                  : "Next →"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function hexToRgb(hex: string): string {
+  const clean = hex.replace("#", "");
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  return `${r},${g},${b}`;
+}

--- a/src/components/learn/SliderPlayground.tsx
+++ b/src/components/learn/SliderPlayground.tsx
@@ -1,0 +1,510 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import type { PlaygroundContent, PlaygroundSlider } from "@/types/content";
+
+interface SliderPlaygroundProps extends PlaygroundContent {
+  accentColor?: string;
+}
+
+// Distinct palette for chunk coloring (muted, dark-theme friendly)
+const CHUNK_COLORS = [
+  "rgba(59,130,246,0.25)", // blue
+  "rgba(139,92,246,0.25)", // purple
+  "rgba(16,185,129,0.25)", // green
+  "rgba(245,158,11,0.25)", // amber
+  "rgba(239,68,68,0.25)", // red
+  "rgba(236,72,153,0.25)", // pink
+  "rgba(20,184,166,0.25)", // teal
+  "rgba(249,115,22,0.25)", // orange
+];
+
+const CHUNK_BORDER_COLORS = [
+  "rgba(59,130,246,0.6)",
+  "rgba(139,92,246,0.6)",
+  "rgba(16,185,129,0.6)",
+  "rgba(245,158,11,0.6)",
+  "rgba(239,68,68,0.6)",
+  "rgba(236,72,153,0.6)",
+  "rgba(20,184,166,0.6)",
+  "rgba(249,115,22,0.6)",
+];
+
+// ────────────────────────────────────────────────────────────────────────────
+// Built-in renderer: chunkPreview
+// ────────────────────────────────────────────────────────────────────────────
+interface ChunkPreviewProps {
+  values: Record<string, number>;
+  sampleText: string;
+}
+
+function ChunkPreview({ values, sampleText }: ChunkPreviewProps) {
+  const chunkSize = Math.max(1, values.chunkSize ?? 80);
+  const overlap = Math.min(Math.max(0, values.overlap ?? 20), chunkSize - 1);
+
+  const chunks = useMemo(() => {
+    const words = sampleText.split(/\s+/);
+    // Simulate token-based chunking using words as token proxies
+    const avgTokenPerWord = 1.3;
+    const chunkWords = Math.max(1, Math.round(chunkSize / avgTokenPerWord));
+    const overlapWords = Math.max(0, Math.round(overlap / avgTokenPerWord));
+    const stride = Math.max(1, chunkWords - overlapWords);
+
+    const result: { text: string; start: number; end: number }[] = [];
+    let start = 0;
+    while (start < words.length) {
+      const end = Math.min(start + chunkWords, words.length);
+      result.push({
+        text: words.slice(start, end).join(" "),
+        start,
+        end,
+      });
+      if (end >= words.length) break;
+      start += stride;
+    }
+    return result;
+  }, [sampleText, chunkSize, overlap]);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <span
+          className="text-xs font-medium"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          Preview: {chunks.length} chunk{chunks.length !== 1 ? "s" : ""}
+        </span>
+        <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+          ~{chunkSize} tokens each, {overlap} overlap
+        </span>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        {chunks.map((chunk, i) => {
+          const colorIdx = i % CHUNK_COLORS.length;
+          return (
+            <span
+              key={i}
+              className="text-xs px-2 py-1 rounded leading-relaxed"
+              style={{
+                backgroundColor: CHUNK_COLORS[colorIdx],
+                border: `1px solid ${CHUNK_BORDER_COLORS[colorIdx]}`,
+                color: "var(--text-secondary)",
+                fontFamily: "var(--font-mono), monospace",
+              }}
+              title={`Chunk ${i + 1} (${chunk.end - chunk.start} words)`}
+            >
+              {chunk.text.length > 60
+                ? chunk.text.slice(0, 57) + "…"
+                : chunk.text}
+            </span>
+          );
+        })}
+      </div>
+
+      {overlap > 0 && (
+        <p className="text-xs mt-2" style={{ color: "var(--text-muted)" }}>
+          Adjacent chunks share ~{overlap} overlapping tokens to preserve
+          context across boundaries.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Built-in renderer: costCalculator
+// ────────────────────────────────────────────────────────────────────────────
+interface CostCalculatorProps {
+  values: Record<string, number>;
+}
+
+// Embedding model cost ($/1K tokens): mapped from slider value 1-5
+const EMBED_COSTS = [0.00002, 0.0001, 0.0002, 0.001, 0.002];
+const EMBED_NAMES = [
+  "text-embedding-3-small",
+  "text-embedding-3-large",
+  "Cohere Embed v3",
+  "Custom Hosted",
+  "Voyage AI",
+];
+
+// LLM model cost ($/1K tokens): mapped from slider value 1-5
+const LLM_COSTS = [0.001, 0.002, 0.01, 0.06, 0.15];
+const LLM_NAMES = [
+  "GPT-3.5 Turbo",
+  "GPT-4o Mini",
+  "Llama-3 70B",
+  "Claude 3 Sonnet",
+  "GPT-4o",
+];
+
+function CostCalculator({ values }: CostCalculatorProps) {
+  const queriesPerDay = Math.max(1, values.queriesPerDay ?? 1000);
+  const embedModel =
+    Math.min(5, Math.max(1, Math.round(values.embeddingModel ?? 1))) - 1;
+  const llmModel =
+    Math.min(5, Math.max(1, Math.round(values.llmModel ?? 1))) - 1;
+  const tokensPerQuery = Math.max(100, values.tokensPerQuery ?? 500);
+
+  const embedCostPerQuery =
+    (tokensPerQuery / 1000) * (EMBED_COSTS[embedModel] ?? 0.00002);
+  const llmCostPerQuery =
+    ((tokensPerQuery * 2) / 1000) * (LLM_COSTS[llmModel] ?? 0.001); // 2x for input+output estimate
+  const totalPerQuery = embedCostPerQuery + llmCostPerQuery;
+  const totalPerDay = totalPerQuery * queriesPerDay;
+  const totalPerMonth = totalPerDay * 30;
+
+  const fmt = (n: number) =>
+    n < 0.01
+      ? `$${(n * 1000).toFixed(3)}m` // millidollars
+      : n < 1
+        ? `$${n.toFixed(4)}`
+        : `$${n.toFixed(2)}`;
+
+  const rows = [
+    {
+      label: "Embedding cost / query",
+      value: fmt(embedCostPerQuery),
+      detail: EMBED_NAMES[embedModel],
+    },
+    {
+      label: "LLM cost / query",
+      value: fmt(llmCostPerQuery),
+      detail: LLM_NAMES[llmModel],
+    },
+    { label: "Total / query", value: fmt(totalPerQuery), detail: "" },
+    {
+      label: "Daily total",
+      value: fmt(totalPerDay),
+      detail: `${queriesPerDay.toLocaleString()} queries`,
+    },
+    {
+      label: "Monthly estimate",
+      value: fmt(totalPerMonth),
+      detail: "30-day projection",
+      highlight: true,
+    },
+  ];
+
+  return (
+    <div>
+      <table className="w-full text-sm border-collapse">
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.label}
+              style={{
+                borderBottom: "1px solid rgba(255,255,255,0.05)",
+                backgroundColor: row.highlight
+                  ? "rgba(245,197,66,0.06)"
+                  : "transparent",
+              }}
+            >
+              <td
+                className="py-2 pr-4 text-xs"
+                style={{ color: "var(--text-muted)" }}
+              >
+                {row.label}
+              </td>
+              <td
+                className="py-2 text-right font-mono font-medium text-sm"
+                style={{
+                  color: row.highlight ? "#f5c542" : "var(--text-primary)",
+                }}
+              >
+                {row.value}
+              </td>
+              {row.detail && (
+                <td
+                  className="py-2 pl-4 text-xs text-right"
+                  style={{ color: "var(--text-muted)" }}
+                >
+                  {row.detail}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Built-in renderer: dimensionPreview
+// ────────────────────────────────────────────────────────────────────────────
+interface DimensionPreviewProps {
+  values: Record<string, number>;
+  accentColor: string;
+}
+
+function DimensionPreview({ values, accentColor }: DimensionPreviewProps) {
+  const dims = Math.max(64, Math.min(3072, values.dimensions ?? 768));
+
+  // Relative quality score (logarithmic — more dims = diminishing returns past 768)
+  const qualityScore = Math.min(
+    100,
+    Math.round((Math.log(dims) / Math.log(3072)) * 115),
+  );
+  // Storage: linear (768 dims = baseline 1.0)
+  const storageScore = Math.round((dims / 768) * 100);
+  // Latency: slight increase with dims
+  const latencyScore = Math.round(50 + (dims / 3072) * 50);
+
+  const bars = [
+    { label: "Retrieval Quality", score: qualityScore, color: accentColor },
+    { label: "Storage Cost", score: storageScore, color: "#ef4444" },
+    { label: "Search Latency", score: latencyScore, color: "#f59e0b" },
+  ];
+
+  return (
+    <div>
+      <div
+        className="mb-4 text-xs flex items-center gap-3"
+        style={{ color: "var(--text-muted)" }}
+      >
+        <span
+          className="font-mono font-medium text-sm"
+          style={{ color: "var(--text-primary)" }}
+        >
+          {dims}d
+        </span>
+        <span>embedding dimensions</span>
+      </div>
+      <div className="space-y-3">
+        {bars.map((bar) => (
+          <div key={bar.label}>
+            <div className="flex items-center justify-between mb-1">
+              <span
+                className="text-xs"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                {bar.label}
+              </span>
+              <span className="text-xs font-mono" style={{ color: bar.color }}>
+                {bar.score}%
+              </span>
+            </div>
+            <div
+              className="h-2 rounded-full overflow-hidden"
+              style={{ backgroundColor: "rgba(255,255,255,0.06)" }}
+            >
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: `${bar.score}%`,
+                  backgroundColor: bar.color,
+                  transition: "width 100ms ease",
+                  opacity: 0.8,
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs mt-3" style={{ color: "var(--text-muted)" }}>
+        Sweet spot: 768-1536 dims — best quality/cost ratio. 3072+ dims cost 4x
+        more storage with minimal quality gain.
+      </p>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Main component
+// ────────────────────────────────────────────────────────────────────────────
+export default function SliderPlayground({
+  title,
+  sliders,
+  renderType,
+  sampleText = "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. How vexingly quick daft zebras jump! The five boxing wizards jump quickly.",
+  accentColor = "#3b82f6",
+}: SliderPlaygroundProps) {
+  // Initialize state from defaults
+  const defaults = useMemo(() => {
+    const d: Record<string, number> = {};
+    for (const s of sliders) d[s.name] = s.default;
+    return d;
+  }, [sliders]);
+
+  const [values, setValues] = useState<Record<string, number>>(defaults);
+
+  const handleChange = (name: string, value: number) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleReset = () => setValues(defaults);
+
+  const accentRgb = hexToRgb(accentColor);
+  const isDirty = sliders.some((s) => values[s.name] !== s.default);
+
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ border: "1px solid rgba(255,255,255,0.08)" }}
+    >
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-4 py-2.5"
+        style={{
+          backgroundColor: "rgba(255,255,255,0.03)",
+          borderBottom: "1px solid rgba(255,255,255,0.06)",
+        }}
+      >
+        <span
+          className="text-sm font-medium"
+          style={{ color: "var(--text-primary)" }}
+        >
+          {title}
+        </span>
+        <button
+          onClick={handleReset}
+          disabled={!isDirty}
+          className="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          style={{
+            backgroundColor: "rgba(255,255,255,0.05)",
+            color: "var(--text-muted)",
+            border: "1px solid rgba(255,255,255,0.08)",
+          }}
+          aria-label="Reset all sliders to defaults"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div className="flex flex-col md:flex-row">
+        {/* Sliders panel */}
+        <div
+          className="p-4 space-y-5 md:w-56 shrink-0"
+          style={{
+            borderRight: "1px solid rgba(255,255,255,0.06)",
+            backgroundColor: "rgba(255,255,255,0.01)",
+          }}
+        >
+          {sliders.map((slider) => {
+            const val = values[slider.name] ?? slider.default;
+            const pct = ((val - slider.min) / (slider.max - slider.min)) * 100;
+
+            return (
+              <div key={slider.name}>
+                <div className="flex items-center justify-between mb-1.5">
+                  <label
+                    htmlFor={`slider-${slider.name}`}
+                    className="text-xs font-medium"
+                    style={{ color: "var(--text-secondary)" }}
+                  >
+                    {slider.label}
+                  </label>
+                  <span
+                    className="text-xs font-mono font-medium tabular-nums"
+                    style={{ color: accentColor }}
+                  >
+                    {val}
+                    {slider.unit ? ` ${slider.unit}` : ""}
+                  </span>
+                </div>
+                <div className="relative h-4 flex items-center">
+                  {/* Track background */}
+                  <div
+                    className="absolute left-0 right-0 h-1.5 rounded-full"
+                    style={{ backgroundColor: "rgba(255,255,255,0.08)" }}
+                  />
+                  {/* Track fill */}
+                  <div
+                    className="absolute left-0 h-1.5 rounded-full"
+                    style={{
+                      width: `${pct}%`,
+                      backgroundColor: accentColor,
+                      opacity: 0.7,
+                    }}
+                  />
+                  {/* Input range (invisible but interactive) */}
+                  <input
+                    id={`slider-${slider.name}`}
+                    type="range"
+                    min={slider.min}
+                    max={slider.max}
+                    step={slider.step ?? 1}
+                    value={val}
+                    onChange={(e) =>
+                      handleChange(slider.name, Number(e.target.value))
+                    }
+                    className="absolute left-0 right-0 w-full cursor-pointer"
+                    style={{
+                      appearance: "none",
+                      WebkitAppearance: "none",
+                      background: "transparent",
+                      height: 16,
+                      margin: 0,
+                      padding: 0,
+                    }}
+                    aria-label={`${slider.label}: ${val}${slider.unit ? " " + slider.unit : ""}`}
+                  />
+                </div>
+                <div
+                  className="flex justify-between text-[10px] mt-0.5"
+                  style={{ color: "var(--text-muted)" }}
+                >
+                  <span>
+                    {slider.min}
+                    {slider.unit ? slider.unit[0] : ""}
+                  </span>
+                  <span>
+                    {slider.max}
+                    {slider.unit ? slider.unit[0] : ""}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Preview panel */}
+        <div
+          className="flex-1 p-4"
+          style={{ backgroundColor: `rgba(${accentRgb}, 0.02)` }}
+        >
+          <div
+            className="text-xs font-semibold uppercase tracking-widest mb-3"
+            style={{ color: "var(--text-muted)" }}
+          >
+            Live Preview
+          </div>
+
+          {renderType === "chunkPreview" && (
+            <ChunkPreview values={values} sampleText={sampleText} />
+          )}
+          {renderType === "costCalculator" && (
+            <CostCalculator values={values} />
+          )}
+          {renderType === "dimensionPreview" && (
+            <DimensionPreview values={values} accentColor={accentColor} />
+          )}
+          {(renderType === "custom" ||
+            !["chunkPreview", "costCalculator", "dimensionPreview"].includes(
+              renderType,
+            )) && (
+            <div className="text-xs" style={{ color: "var(--text-muted)" }}>
+              Custom renderer: <code className="font-mono">{renderType}</code>
+              <pre
+                className="mt-2 rounded-lg p-3 text-xs overflow-x-auto"
+                style={{ backgroundColor: "var(--code-bg)", color: "#94a3b8" }}
+              >
+                {JSON.stringify(values, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function hexToRgb(hex: string): string {
+  const clean = hex.replace("#", "");
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  return `${r},${g},${b}`;
+}

--- a/src/components/learn/StepReveal.tsx
+++ b/src/components/learn/StepReveal.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { StepsContent } from "@/types/content";
+import MarkdownText from "./MarkdownText";
+
+interface StepRevealProps extends StepsContent {
+  accentColor?: string;
+}
+
+export default function StepReveal({
+  steps,
+  accentColor = "#3b82f6",
+}: StepRevealProps) {
+  const [current, setCurrent] = useState(0);
+  const [visible, setVisible] = useState(true);
+
+  const total = steps.length;
+
+  const goTo = useCallback(
+    (index: number) => {
+      if (index < 0 || index >= total || index === current) return;
+      setVisible(false);
+      setTimeout(() => {
+        setCurrent(index);
+        setVisible(true);
+      }, 100);
+    },
+    [current, total],
+  );
+
+  const handlePrev = () => goTo(current - 1);
+  const handleNext = () => {
+    if (current < total - 1) goTo(current + 1);
+  };
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        goTo(current - 1);
+      }
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        goTo(current + 1);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [current, goTo]);
+
+  const step = steps[current];
+  if (!step) return null;
+
+  const accentRgb = hexToRgb(accentColor);
+
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ border: "1px solid rgba(255,255,255,0.08)" }}
+    >
+      {/* Header: step counter + progress bar */}
+      <div
+        className="px-5 pt-4 pb-3"
+        style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}
+      >
+        <div className="flex items-center justify-between mb-2">
+          <span
+            className="text-xs font-semibold uppercase tracking-widest"
+            style={{ color: "var(--text-muted)" }}
+          >
+            Step {current + 1} of {total}
+          </span>
+          {/* Progress fraction */}
+          <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+            {Math.round(((current + 1) / total) * 100)}%
+          </span>
+        </div>
+        {/* Thin progress bar */}
+        <div
+          className="h-1 rounded-full overflow-hidden"
+          style={{ backgroundColor: "rgba(255,255,255,0.06)" }}
+        >
+          <div
+            className="h-full rounded-full"
+            style={{
+              width: `${((current + 1) / total) * 100}%`,
+              backgroundColor: accentColor,
+              transition: "width 250ms ease",
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Content area with fade */}
+      <div
+        className="px-5 py-5"
+        style={{
+          opacity: visible ? 1 : 0,
+          transition: "opacity 150ms ease",
+          minHeight: 120,
+          backgroundColor: `rgba(${accentRgb}, 0.025)`,
+        }}
+      >
+        {/* Step number badge + title */}
+        <div className="flex items-start gap-3 mb-4">
+          <span
+            className="inline-flex items-center justify-center shrink-0 rounded-full text-xs font-bold"
+            style={{
+              width: 28,
+              height: 28,
+              backgroundColor: accentColor,
+              color: "#fff",
+              marginTop: 1,
+            }}
+          >
+            {current + 1}
+          </span>
+          <h3
+            className="text-base font-semibold"
+            style={{ color: "var(--text-primary)", lineHeight: 1.4 }}
+          >
+            {step.title}
+          </h3>
+        </div>
+
+        {/* Markdown content */}
+        <div className="pl-10">
+          <MarkdownText content={step.content} />
+
+          {/* Optional visual reference */}
+          {step.visual && (
+            <div
+              className="mt-3 text-xs rounded-lg px-3 py-2"
+              style={{
+                backgroundColor: "rgba(255,255,255,0.03)",
+                border: "1px solid rgba(255,255,255,0.06)",
+                color: "var(--text-muted)",
+              }}
+            >
+              <span className="font-mono">{step.visual}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Dot indicators + nav buttons */}
+      <div
+        className="flex items-center justify-between px-5 py-3"
+        style={{
+          borderTop: "1px solid rgba(255,255,255,0.06)",
+          backgroundColor: "rgba(255,255,255,0.02)",
+        }}
+      >
+        {/* Prev button */}
+        <button
+          onClick={handlePrev}
+          disabled={current === 0}
+          className="text-xs px-3 py-1.5 rounded cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          style={{
+            backgroundColor: "rgba(255,255,255,0.05)",
+            color: "var(--text-secondary)",
+            border: "1px solid rgba(255,255,255,0.1)",
+          }}
+          aria-label="Previous step"
+        >
+          ← Prev
+        </button>
+
+        {/* Dot indicators */}
+        <div
+          className="flex items-center gap-1.5"
+          role="tablist"
+          aria-label="Step navigation"
+        >
+          {steps.map((s, i) => (
+            <button
+              key={i}
+              role="tab"
+              aria-selected={i === current}
+              aria-label={`Step ${i + 1}: ${s.title}`}
+              onClick={() => goTo(i)}
+              className="rounded-full cursor-pointer transition-all"
+              style={{
+                width: i === current ? 20 : 6,
+                height: 6,
+                backgroundColor:
+                  i === current
+                    ? accentColor
+                    : i < current
+                      ? `rgba(${accentRgb}, 0.4)`
+                      : "rgba(255,255,255,0.15)",
+                transition: "width 200ms ease, background-color 200ms ease",
+              }}
+            />
+          ))}
+        </div>
+
+        {/* Next / Done button */}
+        <button
+          onClick={handleNext}
+          disabled={current === total - 1}
+          className="text-xs px-3 py-1.5 rounded cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          style={{
+            backgroundColor:
+              current === total - 1 ? "rgba(255,255,255,0.05)" : accentColor,
+            color: current === total - 1 ? "var(--text-muted)" : "#fff",
+            border: `1px solid ${current === total - 1 ? "rgba(255,255,255,0.1)" : accentColor}`,
+          }}
+          aria-label={current === total - 1 ? "Last step" : "Next step"}
+        >
+          {current === total - 1 ? "Done ✓" : "Next →"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function hexToRgb(hex: string): string {
+  const clean = hex.replace("#", "");
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  return `${r},${g},${b}`;
+}


### PR DESCRIPTION
## Summary
5 interactive learn components per PRD §9:

- **AnnotatedCode** — regex syntax highlighting (Python/JS/SQL/bash), numbered annotation markers, click-to-highlight, auto-walk mode, clipboard copy
- **PipelineDiagram** — SVG with topological auto-layout, animated dashed edges (flowPulse), click nodes for descriptions, step-through mode with keyboard nav
- **BeforeAfter** — two-tab with red/green tints, 150ms crossfade, accessible tablist
- **StepReveal** — step counter + progress bar, fade-in transitions, clickable dot indicators, keyboard nav
- **SliderPlayground** — custom styled sliders, 3 built-in renderers (chunkPreview, costCalculator, dimensionPreview), real-time updates

LearnPanel updated to route all 7 section types to real components.

## PRD Compliance
- §9 AnnotatedCode: annotations, copy, auto-walk ✓
- §9 PipelineDiagram: SVG, animation, step-through, keyboard ✓
- §9 BeforeAfter: tabs, crossfade, accessible ✓
- §9 StepReveal: dots, prev/next, keyboard ✓
- §9 SliderPlayground: 3 renderers, real-time, reset ✓

## Test plan
- [x] `npm run build` passes (zero TS errors)
- [ ] Each component renders with sample data
- [ ] Keyboard navigation works on all interactive components

🤖 Generated with [Claude Code](https://claude.com/claude-code)