### PR TITLE
fix: level navigation + light mode component styling (15 files)

### DIFF
--- a/src/components/games/ArchitectureBattle.tsx
+++ b/src/components/games/ArchitectureBattle.tsx
@@ -86,7 +86,7 @@ export default function ArchitectureBattle({
                 <div
                   className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold"
                   style={{
-                    backgroundColor: "rgba(255,255,255,0.05)",
+                    backgroundColor: "var(--color-bg-surface)",
                     color: "var(--text-muted)",
                   }}
                 >
@@ -106,7 +106,7 @@ export default function ArchitectureBattle({
                       ? "rgba(239,68,68,0.10)"
                       : isSelected
                         ? `${accentColor}15`
-                        : "rgba(255,255,255,0.03)",
+                        : "var(--color-bg-surface)",
                   border: `2px solid ${
                     isCorrect
                       ? "var(--success)"
@@ -114,7 +114,7 @@ export default function ArchitectureBattle({
                         ? "var(--error)"
                         : isSelected
                           ? accentColor
-                          : "rgba(255,255,255,0.08)"
+                          : "var(--color-border)"
                   }`,
                   cursor: submitted ? "default" : "pointer",
                   transform:
@@ -177,7 +177,7 @@ export default function ArchitectureBattle({
       <div className="flex sm:hidden items-center justify-center">
         <div
           className="h-px flex-1"
-          style={{ backgroundColor: "rgba(255,255,255,0.08)" }}
+          style={{ backgroundColor: "var(--color-border)" }}
         />
         <span
           className="px-3 text-xs font-bold"
@@ -187,7 +187,7 @@ export default function ArchitectureBattle({
         </span>
         <div
           className="h-px flex-1"
-          style={{ backgroundColor: "rgba(255,255,255,0.08)" }}
+          style={{ backgroundColor: "var(--color-border)" }}
         />
       </div>
 
@@ -202,7 +202,7 @@ export default function ArchitectureBattle({
           className="rounded-xl py-2.5 text-sm font-semibold transition-[background-color,color]"
           style={{
             backgroundColor:
-              selected !== null ? accentColor : "rgba(255,255,255,0.05)",
+              selected !== null ? accentColor : "var(--color-bg-surface)",
             color: selected !== null ? "#0c0c14" : "var(--text-muted)",
             cursor: selected !== null ? "pointer" : "not-allowed",
           }}

--- a/src/components/games/CodeDebugger.tsx
+++ b/src/components/games/CodeDebugger.tsx
@@ -68,11 +68,11 @@ export default function CodeDebugger({
       {/* Code block */}
       <div
         className="rounded-xl overflow-hidden"
-        style={{ border: "1px solid rgba(255,255,255,0.08)" }}
+        style={{ border: "1px solid var(--color-border)" }}
       >
         <div
           className="px-3 py-2 flex items-center gap-2"
-          style={{ backgroundColor: "rgba(255,255,255,0.04)" }}
+          style={{ backgroundColor: "var(--color-bg-surface)" }}
         >
           <span
             className="text-xs font-mono"
@@ -123,8 +123,8 @@ export default function CodeDebugger({
       {/* Options */}
       <div className="flex flex-col gap-2">
         {currentBug.options.map((opt, i) => {
-          let bg = "rgba(255,255,255,0.03)";
-          let border = "rgba(255,255,255,0.08)";
+          let bg = "var(--color-bg-surface)";
+          let border = "var(--color-border)";
           let textColor = "var(--text-secondary)";
 
           if (submitted) {

--- a/src/components/games/ConceptMatcher.tsx
+++ b/src/components/games/ConceptMatcher.tsx
@@ -103,13 +103,13 @@ export default function ConceptMatcher({
                     ? "rgba(245,197,66,0.10)"
                     : isSelected
                       ? `${accentColor}20`
-                      : "rgba(255,255,255,0.03)",
+                      : "var(--color-bg-surface)",
                   border: `1px solid ${
                     isMatched
                       ? "rgba(245,197,66,0.40)"
                       : isSelected
                         ? accentColor
-                        : "rgba(255,255,255,0.08)"
+                        : "var(--color-border)"
                   }`,
                   color: isMatched
                     ? "var(--success)"
@@ -152,15 +152,15 @@ export default function ConceptMatcher({
                     ? "rgba(245,197,66,0.10)"
                     : isWrong
                       ? "rgba(239,68,68,0.12)"
-                      : "rgba(255,255,255,0.03)",
+                      : "var(--color-bg-surface)",
                   border: `1px solid ${
                     isMatched
                       ? "rgba(245,197,66,0.40)"
                       : isWrong
                         ? "var(--error)"
                         : selectedLeft !== null
-                          ? "rgba(255,255,255,0.12)"
-                          : "rgba(255,255,255,0.08)"
+                          ? "var(--color-text-muted)"
+                          : "var(--color-border)"
                   }`,
                   color: isMatched
                     ? "var(--success)"

--- a/src/components/games/CostOptimizer.tsx
+++ b/src/components/games/CostOptimizer.tsx
@@ -69,8 +69,8 @@ export default function CostOptimizer({
           style={{
             backgroundColor: allOptimal
               ? "rgba(245,197,66,0.08)"
-              : "rgba(255,255,255,0.03)",
-            border: `1px solid ${allOptimal ? "rgba(245,197,66,0.3)" : "rgba(255,255,255,0.08)"}`,
+              : "var(--color-bg-surface)",
+            border: `1px solid ${allOptimal ? "rgba(245,197,66,0.3)" : "var(--color-border)"}`,
           }}
         >
           <span style={{ color: "var(--text-muted)" }}>Balance status</span>
@@ -123,7 +123,7 @@ export default function CostOptimizer({
               {/* Visual gauge */}
               <div
                 className="relative h-2 rounded-full"
-                style={{ backgroundColor: "rgba(255,255,255,0.08)" }}
+                style={{ backgroundColor: "var(--color-border)" }}
               >
                 {/* Optimal target line */}
                 {submitted && (
@@ -213,8 +213,8 @@ export default function CostOptimizer({
         <div
           className="rounded-xl p-4 flex flex-col gap-2"
           style={{
-            backgroundColor: "rgba(255,255,255,0.03)",
-            border: "1px solid rgba(255,255,255,0.08)",
+            backgroundColor: "var(--color-bg-surface)",
+            border: "1px solid var(--color-border)",
           }}
         >
           <p

--- a/src/components/games/DiagnosisLab.tsx
+++ b/src/components/games/DiagnosisLab.tsx
@@ -154,8 +154,8 @@ export default function DiagnosisLab({
       {/* Options */}
       <div className="flex flex-col gap-2">
         {current.options.map((opt, i) => {
-          let bg = "rgba(255,255,255,0.03)";
-          let border = "rgba(255,255,255,0.08)";
+          let bg = "var(--color-bg-surface)";
+          let border = "var(--color-border)";
           let textColor = "var(--text-secondary)";
 
           if (submitted) {

--- a/src/components/games/GamePanel.tsx
+++ b/src/components/games/GamePanel.tsx
@@ -316,7 +316,7 @@ export default function GamePanel({
             onClick={handleRetry}
             className="mt-4 rounded-xl py-2.5 text-sm font-semibold w-full"
             style={{
-              backgroundColor: "rgba(255,255,255,0.05)",
+              backgroundColor: "var(--color-bg-surface)",
               color: "var(--color-text-secondary)",
               border: "1px solid var(--color-border)",
               transition:

--- a/src/components/games/ParameterTuner.tsx
+++ b/src/components/games/ParameterTuner.tsx
@@ -103,7 +103,7 @@ export default function ParameterTuner({
               {/* Gauge bar */}
               <div
                 className="relative h-2 rounded-full overflow-visible"
-                style={{ backgroundColor: "rgba(255,255,255,0.08)" }}
+                style={{ backgroundColor: "var(--color-border)" }}
               >
                 {/* Optimal marker */}
                 {submitted && (

--- a/src/components/games/PipelineBuilder.tsx
+++ b/src/components/games/PipelineBuilder.tsx
@@ -147,8 +147,8 @@ export default function PipelineBuilder({
       <div
         className="flex flex-wrap gap-2 p-3 rounded-xl min-h-[52px]"
         style={{
-          backgroundColor: "rgba(255,255,255,0.02)",
-          border: "1px dashed rgba(255,255,255,0.1)",
+          backgroundColor: "var(--color-bg-surface)",
+          border: "1px dashed var(--color-border)",
         }}
         onDragOver={(e) => e.preventDefault()}
         onDrop={onDropPool}
@@ -211,10 +211,10 @@ export default function PipelineBuilder({
                       : isWrong
                         ? "rgba(239,68,68,0.12)"
                         : `${accentColor}10`
-                    : "rgba(255,255,255,0.03)",
+                    : "var(--color-bg-surface)",
                   border: slot
                     ? `1px solid ${isCorrect ? "var(--success)" : isWrong ? "var(--error)" : accentColor}60`
-                    : "1px dashed rgba(255,255,255,0.12)",
+                    : "1px dashed var(--color-text-muted)",
                   color: slot
                     ? isCorrect
                       ? "var(--success)"
@@ -260,7 +260,9 @@ export default function PipelineBuilder({
           onClick={checkPipeline}
           className="rounded-xl py-2.5 text-sm font-semibold transition-[background-color,color]"
           style={{
-            backgroundColor: allFilled ? accentColor : "rgba(255,255,255,0.05)",
+            backgroundColor: allFilled
+              ? accentColor
+              : "var(--color-bg-surface)",
             color: allFilled ? "#0c0c14" : "var(--text-muted)",
             cursor: allFilled ? "pointer" : "not-allowed",
           }}

--- a/src/components/games/SpeedQuiz.tsx
+++ b/src/components/games/SpeedQuiz.tsx
@@ -111,7 +111,7 @@ export default function SpeedQuiz({
       {/* Timer bar */}
       <div
         className="h-1 rounded-full overflow-hidden"
-        style={{ backgroundColor: "rgba(255,255,255,0.08)" }}
+        style={{ backgroundColor: "var(--color-border)" }}
       >
         <div
           className="h-full rounded-full"
@@ -138,8 +138,8 @@ export default function SpeedQuiz({
       {/* Options */}
       <div className="flex flex-col gap-2">
         {currentQ.options.map((opt, i) => {
-          let bg = "rgba(255,255,255,0.03)";
-          let border = "rgba(255,255,255,0.08)";
+          let bg = "var(--color-bg-surface)";
+          let border = "var(--color-border)";
           let textColor = "var(--text-secondary)";
 
           if (answered) {
@@ -153,7 +153,7 @@ export default function SpeedQuiz({
               textColor = "var(--error)";
             }
           } else if (!answered) {
-            bg = "rgba(255,255,255,0.03)";
+            bg = "var(--color-bg-surface)";
           }
 
           return (
@@ -178,7 +178,7 @@ export default function SpeedQuiz({
                       ? "rgba(245,197,66,0.2)"
                       : i === selectedIdx
                         ? "rgba(239,68,68,0.2)"
-                        : "rgba(255,255,255,0.06)"
+                        : "var(--color-border)"
                     : `${accentColor}20`,
                   color: answered
                     ? i === currentQ.correct

--- a/src/components/hud/LevelComplete.tsx
+++ b/src/components/hud/LevelComplete.tsx
@@ -253,7 +253,7 @@ export default function LevelComplete({
         <div className="w-full">
           <div
             className="w-full h-2 rounded-full overflow-hidden"
-            style={{ backgroundColor: "rgba(255,255,255,0.08)" }}
+            style={{ backgroundColor: "var(--color-border)" }}
           >
             <div
               className="h-full rounded-full"
@@ -315,18 +315,33 @@ export default function LevelComplete({
               Next Level →
             </Link>
           )}
+          {nextLevelUrl && !passed && (
+            <Link
+              href={nextLevelUrl}
+              className="w-full rounded-xl py-3 text-sm font-medium text-center block"
+              style={{
+                backgroundColor: "transparent",
+                color: "var(--color-text-muted)",
+                border: "1px solid var(--color-border)",
+                transition:
+                  "background-color 150ms ease, border-color 150ms ease",
+              }}
+            >
+              Continue Anyway →
+            </Link>
+          )}
           <Link
             href={backUrl}
             className="w-full rounded-xl py-3 text-sm font-medium text-center block"
             style={{
-              backgroundColor: "rgba(255,255,255,0.05)",
+              backgroundColor: "var(--color-bg-surface)",
               color: "var(--color-text-secondary)",
               border: "1px solid var(--color-border)",
               transition:
                 "background-color 150ms ease, border-color 150ms ease",
             }}
           >
-            {nextLevelUrl && passed ? "Back to Chapter" : "Try Again"}
+            {nextLevelUrl ? "Back to Chapter" : "Try Again"}
           </Link>
         </div>
       </div>

--- a/src/components/learn/AnnotatedCode.tsx
+++ b/src/components/learn/AnnotatedCode.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import type { CodeContent } from "@/types/content";
 
 interface AnnotatedCodeProps extends CodeContent {
@@ -277,7 +277,7 @@ function tokenizeLine(line: string, lang: string): Token[] {
   return tokens;
 }
 
-const TOKEN_COLORS: Record<TokenType, string> = {
+const TOKEN_COLORS_DARK: Record<TokenType, string> = {
   kw: "#c792ea", // purple — keywords
   str: "#c3e88d", // green  — strings
   cmt: "#546e7a", // grey   — comments
@@ -287,7 +287,39 @@ const TOKEN_COLORS: Record<TokenType, string> = {
   plain: "#e2e8f0", // white  — default
 };
 
-function renderLine(line: string, lang: string) {
+const TOKEN_COLORS_LIGHT: Record<TokenType, string> = {
+  kw: "#7c3aed", // purple — keywords
+  str: "#16a34a", // green  — strings
+  cmt: "#64748b", // grey   — comments
+  num: "#ea580c", // orange — numbers
+  fn: "#2563eb", // blue   — function calls
+  op: "#0891b2", // cyan   — operators
+  plain: "#1e293b", // dark  — default
+};
+
+function useIsDarkTheme(): boolean {
+  const [isDark, setIsDark] = useState(true);
+
+  useEffect(() => {
+    const check = () => {
+      setIsDark(
+        document.documentElement.getAttribute("data-theme") !== "light",
+      );
+    };
+    check();
+    const observer = new MutationObserver(check);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return isDark;
+}
+
+function renderLine(line: string, lang: string, isDark: boolean) {
+  const TOKEN_COLORS = isDark ? TOKEN_COLORS_DARK : TOKEN_COLORS_LIGHT;
   const tokens = tokenizeLine(line, lang);
   return tokens.map((tok, i) => (
     <span key={i} style={{ color: TOKEN_COLORS[tok.type] }}>
@@ -308,6 +340,7 @@ export default function AnnotatedCode({
 }: AnnotatedCodeProps) {
   const [activeAnnotation, setActiveAnnotation] = useState<number | null>(null);
   const [copied, setCopied] = useState(false);
+  const isDark = useIsDarkTheme();
 
   const lines = code.split("\n");
 
@@ -360,21 +393,21 @@ export default function AnnotatedCode({
   return (
     <div
       className="rounded-xl overflow-hidden"
-      style={{ border: "1px solid rgba(255,255,255,0.08)" }}
+      style={{ border: "1px solid var(--color-border)" }}
     >
       {/* Header bar */}
       <div
         className="flex items-center justify-between px-4 py-2.5"
         style={{
-          backgroundColor: "rgba(255,255,255,0.04)",
-          borderBottom: "1px solid rgba(255,255,255,0.06)",
+          backgroundColor: "var(--color-bg-surface)",
+          borderBottom: "1px solid var(--color-border)",
         }}
       >
         <div className="flex items-center gap-2">
           <span
             className="text-xs font-mono px-2 py-0.5 rounded"
             style={{
-              backgroundColor: "rgba(255,255,255,0.06)",
+              backgroundColor: "var(--color-border)",
               color: "var(--text-muted)",
             }}
           >
@@ -394,8 +427,8 @@ export default function AnnotatedCode({
           className="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded transition-colors cursor-pointer"
           style={{
             color: copied ? "#c3e88d" : "var(--text-muted)",
-            backgroundColor: "rgba(255,255,255,0.04)",
-            border: "1px solid rgba(255,255,255,0.08)",
+            backgroundColor: "var(--color-bg-surface)",
+            border: "1px solid var(--color-border)",
           }}
           aria-label="Copy code to clipboard"
         >
@@ -462,7 +495,7 @@ export default function AnnotatedCode({
                     className="select-none text-right pr-4 pl-4 w-8"
                     style={{
                       color: isHighlighted ? accentColor : "var(--text-muted)",
-                      borderRight: "1px solid rgba(255,255,255,0.06)",
+                      borderRight: "1px solid var(--color-border)",
                       userSelect: "none",
                     }}
                   >
@@ -500,7 +533,9 @@ export default function AnnotatedCode({
 
                   {/* Code content */}
                   <td className="py-0.5 pl-2 pr-6 whitespace-pre">
-                    {line === "" ? "\u00A0" : renderLine(line, language)}
+                    {line === ""
+                      ? "\u00A0"
+                      : renderLine(line, language, isDark)}
                   </td>
                 </tr>
               );
@@ -543,8 +578,8 @@ export default function AnnotatedCode({
         <div
           className="flex items-center justify-between px-4 py-2"
           style={{
-            borderTop: "1px solid rgba(255,255,255,0.06)",
-            backgroundColor: "rgba(255,255,255,0.02)",
+            borderTop: "1px solid var(--color-border)",
+            backgroundColor: "var(--color-bg-surface)",
           }}
         >
           <span className="text-xs" style={{ color: "var(--text-muted)" }}>
@@ -557,9 +592,9 @@ export default function AnnotatedCode({
               onClick={handlePrev}
               className="text-xs px-2.5 py-1 rounded cursor-pointer transition-colors"
               style={{
-                backgroundColor: "rgba(255,255,255,0.05)",
+                backgroundColor: "var(--color-bg-card)",
                 color: "var(--text-secondary)",
-                border: "1px solid rgba(255,255,255,0.1)",
+                border: "1px solid var(--color-border)",
               }}
               aria-label="Previous annotation"
             >
@@ -569,9 +604,9 @@ export default function AnnotatedCode({
               onClick={handleNext}
               className="text-xs px-2.5 py-1 rounded cursor-pointer transition-colors"
               style={{
-                backgroundColor: "rgba(255,255,255,0.05)",
+                backgroundColor: "var(--color-bg-card)",
                 color: "var(--text-secondary)",
-                border: "1px solid rgba(255,255,255,0.1)",
+                border: "1px solid var(--color-border)",
               }}
               aria-label="Next annotation"
             >

--- a/src/components/learn/BeforeAfter.tsx
+++ b/src/components/learn/BeforeAfter.tsx
@@ -43,14 +43,14 @@ export default function BeforeAfter({
   return (
     <div
       className="rounded-xl overflow-hidden"
-      style={{ border: "1px solid rgba(255,255,255,0.08)" }}
+      style={{ border: "1px solid var(--color-border)" }}
     >
       {/* Tab bar */}
       <div
         className="flex"
         role="tablist"
         aria-label="Before and after comparison"
-        style={{ borderBottom: "1px solid rgba(255,255,255,0.08)" }}
+        style={{ borderBottom: "1px solid var(--color-border)" }}
       >
         {/* Before tab */}
         <button
@@ -64,9 +64,9 @@ export default function BeforeAfter({
             backgroundColor:
               activeTab === "before"
                 ? "rgba(239,68,68,0.08)"
-                : "rgba(255,255,255,0.02)",
+                : "var(--color-bg-surface)",
             color: activeTab === "before" ? "#ef4444" : "var(--text-muted)",
-            borderRight: "1px solid rgba(255,255,255,0.06)",
+            borderRight: "1px solid var(--color-border)",
           }}
         >
           {/* Before icon: X circle */}
@@ -105,7 +105,7 @@ export default function BeforeAfter({
             backgroundColor:
               activeTab === "after"
                 ? "rgba(16,185,129,0.08)"
-                : "rgba(255,255,255,0.02)",
+                : "var(--color-bg-surface)",
             color: activeTab === "after" ? "#10b981" : "var(--text-muted)",
           }}
         >

--- a/src/components/learn/PipelineDiagram.tsx
+++ b/src/components/learn/PipelineDiagram.tsx
@@ -212,14 +212,14 @@ export default function PipelineDiagram({
   return (
     <div
       className="rounded-xl overflow-hidden"
-      style={{ border: "1px solid rgba(255,255,255,0.08)" }}
+      style={{ border: "1px solid var(--color-border)" }}
     >
       {/* Header */}
       <div
         className="flex items-center justify-between px-4 py-2.5"
         style={{
-          backgroundColor: "rgba(255,255,255,0.03)",
-          borderBottom: "1px solid rgba(255,255,255,0.06)",
+          backgroundColor: "var(--color-bg-surface)",
+          borderBottom: "1px solid var(--color-border)",
         }}
       >
         <span
@@ -261,7 +261,7 @@ export default function PipelineDiagram({
               refY="3"
               orient="auto"
             >
-              <path d="M0,0 L8,3 L0,6 Z" fill="rgba(255,255,255,0.25)" />
+              <path d="M0,0 L8,3 L0,6 Z" fill="var(--color-text-muted)" />
             </marker>
             <marker
               id="arrow-active"
@@ -290,7 +290,7 @@ export default function PipelineDiagram({
                     ? accentColor
                     : active
                       ? accentColor
-                      : "rgba(255,255,255,0.2)"
+                      : "var(--color-text-muted)"
                 }
                 strokeWidth={isCurrent ? 2 : 1.5}
                 strokeDasharray={active ? "8 12" : undefined}
@@ -356,14 +356,14 @@ export default function PipelineDiagram({
                       ? `rgba(${accentRgb}, 0.18)`
                       : isVisited && stepThrough
                         ? `rgba(${accentRgb}, 0.08)`
-                        : "rgba(255,255,255,0.05)"
+                        : "var(--color-bg-surface)"
                   }
                   stroke={
                     isActive
                       ? accentColor
                       : isTooltipOpen
                         ? accentColor
-                        : "rgba(255,255,255,0.12)"
+                        : "var(--color-border)"
                   }
                   strokeWidth={isActive ? 1.5 : 1}
                   opacity={isDimmed ? 0.35 : 1}
@@ -456,8 +456,8 @@ export default function PipelineDiagram({
         <div
           className="flex items-center justify-between px-4 py-2.5"
           style={{
-            borderTop: "1px solid rgba(255,255,255,0.06)",
-            backgroundColor: "rgba(255,255,255,0.02)",
+            borderTop: "1px solid var(--color-border)",
+            backgroundColor: "var(--color-bg-surface)",
           }}
         >
           <button
@@ -465,7 +465,7 @@ export default function PipelineDiagram({
             className="text-xs px-2.5 py-1 rounded cursor-pointer"
             style={{
               color: "var(--text-muted)",
-              border: "1px solid rgba(255,255,255,0.08)",
+              border: "1px solid var(--color-border)",
             }}
           >
             Reset
@@ -476,9 +476,9 @@ export default function PipelineDiagram({
               disabled={step <= 0}
               className="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
               style={{
-                backgroundColor: "rgba(255,255,255,0.05)",
+                backgroundColor: "var(--color-bg-card)",
                 color: "var(--text-secondary)",
-                border: "1px solid rgba(255,255,255,0.1)",
+                border: "1px solid var(--color-border)",
               }}
               aria-label="Previous step"
             >
@@ -490,9 +490,9 @@ export default function PipelineDiagram({
               className="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
               style={{
                 backgroundColor:
-                  step < 0 ? accentColor : "rgba(255,255,255,0.05)",
+                  step < 0 ? accentColor : "var(--color-bg-card)",
                 color: step < 0 ? "#fff" : "var(--text-secondary)",
-                border: `1px solid ${step < 0 ? accentColor : "rgba(255,255,255,0.1)"}`,
+                border: `1px solid ${step < 0 ? accentColor : "var(--color-border)"}`,
               }}
               aria-label="Next step"
             >

--- a/src/components/learn/SliderPlayground.tsx
+++ b/src/components/learn/SliderPlayground.tsx
@@ -195,7 +195,8 @@ function CostCalculator({ values }: CostCalculatorProps) {
             <tr
               key={row.label}
               style={{
-                borderBottom: "1px solid rgba(255,255,255,0.05)",
+                borderBottom:
+                  "1px solid var(--color-border-subtle, var(--color-border))",
                 backgroundColor: row.highlight
                   ? "rgba(245,197,66,0.06)"
                   : "transparent",
@@ -288,7 +289,7 @@ function DimensionPreview({ values, accentColor }: DimensionPreviewProps) {
             </div>
             <div
               className="h-2 rounded-full overflow-hidden"
-              style={{ backgroundColor: "rgba(255,255,255,0.06)" }}
+              style={{ backgroundColor: "var(--color-border)" }}
             >
               <div
                 className="h-full rounded-full"
@@ -342,14 +343,14 @@ export default function SliderPlayground({
   return (
     <div
       className="rounded-xl overflow-hidden"
-      style={{ border: "1px solid rgba(255,255,255,0.08)" }}
+      style={{ border: "1px solid var(--color-border)" }}
     >
       {/* Header */}
       <div
         className="flex items-center justify-between px-4 py-2.5"
         style={{
-          backgroundColor: "rgba(255,255,255,0.03)",
-          borderBottom: "1px solid rgba(255,255,255,0.06)",
+          backgroundColor: "var(--color-bg-surface)",
+          borderBottom: "1px solid var(--color-border)",
         }}
       >
         <span
@@ -363,9 +364,9 @@ export default function SliderPlayground({
           disabled={!isDirty}
           className="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
           style={{
-            backgroundColor: "rgba(255,255,255,0.05)",
+            backgroundColor: "var(--color-bg-card)",
             color: "var(--text-muted)",
-            border: "1px solid rgba(255,255,255,0.08)",
+            border: "1px solid var(--color-border)",
           }}
           aria-label="Reset all sliders to defaults"
         >
@@ -378,8 +379,8 @@ export default function SliderPlayground({
         <div
           className="p-4 space-y-5 md:w-56 shrink-0"
           style={{
-            borderRight: "1px solid rgba(255,255,255,0.06)",
-            backgroundColor: "rgba(255,255,255,0.01)",
+            borderRight: "1px solid var(--color-border)",
+            backgroundColor: "var(--color-bg-surface)",
           }}
         >
           {sliders.map((slider) => {
@@ -408,7 +409,7 @@ export default function SliderPlayground({
                   {/* Track background */}
                   <div
                     className="absolute left-0 right-0 h-1.5 rounded-full"
-                    style={{ backgroundColor: "rgba(255,255,255,0.08)" }}
+                    style={{ backgroundColor: "var(--color-border)" }}
                   />
                   {/* Track fill */}
                   <div

--- a/src/components/learn/StepReveal.tsx
+++ b/src/components/learn/StepReveal.tsx
@@ -58,12 +58,12 @@ export default function StepReveal({
   return (
     <div
       className="rounded-xl overflow-hidden"
-      style={{ border: "1px solid rgba(255,255,255,0.08)" }}
+      style={{ border: "1px solid var(--color-border)" }}
     >
       {/* Header: step counter + progress bar */}
       <div
         className="px-5 pt-4 pb-3"
-        style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}
+        style={{ borderBottom: "1px solid var(--color-border)" }}
       >
         <div className="flex items-center justify-between mb-2">
           <span
@@ -80,7 +80,7 @@ export default function StepReveal({
         {/* Thin progress bar */}
         <div
           className="h-1 rounded-full overflow-hidden"
-          style={{ backgroundColor: "rgba(255,255,255,0.06)" }}
+          style={{ backgroundColor: "var(--color-border)" }}
         >
           <div
             className="h-full rounded-full"
@@ -134,8 +134,8 @@ export default function StepReveal({
             <div
               className="mt-3 text-xs rounded-lg px-3 py-2"
               style={{
-                backgroundColor: "rgba(255,255,255,0.03)",
-                border: "1px solid rgba(255,255,255,0.06)",
+                backgroundColor: "var(--color-bg-surface)",
+                border: "1px solid var(--color-border)",
                 color: "var(--text-muted)",
               }}
             >
@@ -149,8 +149,8 @@ export default function StepReveal({
       <div
         className="flex items-center justify-between px-5 py-3"
         style={{
-          borderTop: "1px solid rgba(255,255,255,0.06)",
-          backgroundColor: "rgba(255,255,255,0.02)",
+          borderTop: "1px solid var(--color-border)",
+          backgroundColor: "var(--color-bg-surface)",
         }}
       >
         {/* Prev button */}
@@ -159,9 +159,9 @@ export default function StepReveal({
           disabled={current === 0}
           className="text-xs px-3 py-1.5 rounded cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
           style={{
-            backgroundColor: "rgba(255,255,255,0.05)",
+            backgroundColor: "var(--color-bg-card)",
             color: "var(--text-secondary)",
-            border: "1px solid rgba(255,255,255,0.1)",
+            border: "1px solid var(--color-border)",
           }}
           aria-label="Previous step"
         >
@@ -190,7 +190,7 @@ export default function StepReveal({
                     ? accentColor
                     : i < current
                       ? `rgba(${accentRgb}, 0.4)`
-                      : "rgba(255,255,255,0.15)",
+                      : "var(--color-text-muted)",
                 transition: "width 200ms ease, background-color 200ms ease",
               }}
             />
@@ -204,9 +204,9 @@ export default function StepReveal({
           className="text-xs px-3 py-1.5 rounded cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           style={{
             backgroundColor:
-              current === total - 1 ? "rgba(255,255,255,0.05)" : accentColor,
+              current === total - 1 ? "var(--color-bg-card)" : accentColor,
             color: current === total - 1 ? "var(--text-muted)" : "#fff",
-            border: `1px solid ${current === total - 1 ? "rgba(255,255,255,0.1)" : accentColor}`,
+            border: `1px solid ${current === total - 1 ? "var(--color-border)" : accentColor}`,
           }}
           aria-label={current === total - 1 ? "Last step" : "Next step"}
         >


### PR DESCRIPTION
## Summary
### Bug 1: Level navigation blocked
- "Next Level" button was gated on `passed` (score >= 60%) — users who scored below couldn't advance
- Fix: always show advance option. >= 60%: "Next Level →" (accent). < 60%: "Continue Anyway →" (ghost)
- "Back to Chapter" always visible

### Bug 2: Light mode invisible components (50+ fixes across 15 files)
- All `rgba(255,255,255,0.0X)` hardcoded dark-mode values replaced with CSS variables
- Files: all 9 game components, PipelineDiagram, AnnotatedCode, BeforeAfter, StepReveal, SliderPlayground, LevelComplete, GamePanel
- AnnotatedCode: dual-theme syntax highlighting via `useIsDarkTheme` hook + MutationObserver on `data-theme`
- Replacement: subtle bg → `var(--color-bg-surface)`, borders → `var(--color-border)`, strokes → `var(--color-text-muted)`

## Test plan
- [ ] Level complete shows "Continue Anyway" when score < 60%
- [ ] Pipeline diagram nodes visible in light mode
- [ ] Code blocks have readable syntax colors in light mode
- [ ] All game option buttons visible in light mode
- [ ] All 8 game types functional
- [ ] Theme toggle works throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)