### PR TITLE
feat: level page UX redesign — card flow + step outline + Start Challenge

### DIFF
--- a/seed/chapter1-rag.json
+++ b/seed/chapter1-rag.json
@@ -95,7 +95,7 @@
       "is_published": true,
       "learn_sections": [
         {
-          "sort_order": 6,
+          "sort_order": 3,
           "section_type": "text",
           "title": "What is Retrieval-Augmented Generation?",
           "content": {
@@ -150,7 +150,7 @@
           }
         },
         {
-          "sort_order": 7,
+          "sort_order": 9,
           "section_type": "comparison",
           "title": "Keyword Search vs Semantic Search (RAG)",
           "content": {
@@ -165,7 +165,7 @@
           }
         },
         {
-          "sort_order": 8,
+          "sort_order": 10,
           "section_type": "callout",
           "title": "Enterprise Skills Bridge",
           "content": {
@@ -274,7 +274,7 @@
           }
         },
         {
-          "sort_order": 5,
+          "sort_order": 2,
           "section_type": "prediction",
           "title": "Predict: Keyword vs Semantic",
           "content": {
@@ -289,7 +289,7 @@
           }
         },
         {
-          "sort_order": 2,
+          "sort_order": 5,
           "section_type": "exploration",
           "title": "RAG Pipeline Data Flow",
           "content": {
@@ -402,7 +402,7 @@
           }
         },
         {
-          "sort_order": 9,
+          "sort_order": 8,
           "section_type": "prediction",
           "title": "Predict: What Happens with Bad Chunks?",
           "content": {
@@ -417,7 +417,7 @@
           }
         },
         {
-          "sort_order": 10,
+          "sort_order": 11,
           "section_type": "prediction",
           "title": "Predict: Updating Knowledge",
           "content": {
@@ -432,7 +432,7 @@
           }
         },
         {
-          "sort_order": 3,
+          "sort_order": 6,
           "section_type": "d2_diagram",
           "title": "RAG Architecture Overview",
           "content": {
@@ -442,7 +442,7 @@
           }
         },
         {
-          "sort_order": 11,
+          "sort_order": 7,
           "section_type": "d2_diagram",
           "title": "RAG vs Fine-Tuning Decision Tree",
           "content": {
@@ -511,7 +511,7 @@
       "is_published": true,
       "learn_sections": [
         {
-          "sort_order": 1,
+          "sort_order": 3,
           "section_type": "text",
           "title": "Why Chunking Matters More Than Your Embedding Model",
           "content": {
@@ -519,7 +519,7 @@
           }
         },
         {
-          "sort_order": 2,
+          "sort_order": 7,
           "section_type": "playground",
           "title": "Chunk Size Explorer",
           "content": {
@@ -549,7 +549,7 @@
           }
         },
         {
-          "sort_order": 3,
+          "sort_order": 6,
           "section_type": "code",
           "title": "Production Chunking Pipeline",
           "content": {
@@ -573,7 +573,7 @@
           }
         },
         {
-          "sort_order": 4,
+          "sort_order": 8,
           "section_type": "steps",
           "title": "The 4-Step Chunking Pipeline",
           "content": {
@@ -598,7 +598,7 @@
           }
         },
         {
-          "sort_order": 5,
+          "sort_order": 9,
           "section_type": "callout",
           "title": "Production Insight",
           "content": {
@@ -608,7 +608,7 @@
           }
         },
         {
-          "sort_order": 6,
+          "sort_order": 1,
           "section_type": "d2_diagram",
           "title": "Chunking Strategies Comparison",
           "content": {
@@ -618,7 +618,7 @@
           }
         },
         {
-          "sort_order": 7,
+          "sort_order": 5,
           "section_type": "exploration",
           "title": "Chunking Strategies — See the Difference",
           "content": {
@@ -742,7 +742,7 @@
           }
         },
         {
-          "sort_order": 8,
+          "sort_order": 4,
           "section_type": "analogy",
           "title": "Concepts You Already Know",
           "content": {
@@ -805,7 +805,7 @@
           }
         },
         {
-          "sort_order": 9,
+          "sort_order": 2,
           "section_type": "prediction",
           "title": "Predict: The Perfect Chunk Size",
           "content": {
@@ -875,7 +875,7 @@
       "is_published": true,
       "learn_sections": [
         {
-          "sort_order": 1,
+          "sort_order": 3,
           "section_type": "text",
           "title": "How Embeddings Capture Meaning",
           "content": {
@@ -883,7 +883,7 @@
           }
         },
         {
-          "sort_order": 2,
+          "sort_order": 1,
           "section_type": "comparison",
           "title": "Sparse vs Dense Embeddings",
           "content": {
@@ -898,7 +898,7 @@
           }
         },
         {
-          "sort_order": 3,
+          "sort_order": 7,
           "section_type": "code",
           "title": "OpenAI Embedding with Matryoshka Truncation",
           "content": {
@@ -922,7 +922,7 @@
           }
         },
         {
-          "sort_order": 4,
+          "sort_order": 6,
           "section_type": "playground",
           "title": "Embedding Dimension vs Quality/Storage Trade-off",
           "content": {
@@ -942,7 +942,7 @@
           }
         },
         {
-          "sort_order": 5,
+          "sort_order": 8,
           "section_type": "callout",
           "title": "Production Recommendation",
           "content": {
@@ -952,7 +952,7 @@
           }
         },
         {
-          "sort_order": 6,
+          "sort_order": 5,
           "section_type": "exploration",
           "title": "Embedding Models — From Text to Vectors",
           "content": {
@@ -1084,7 +1084,7 @@
           }
         },
         {
-          "sort_order": 7,
+          "sort_order": 4,
           "section_type": "analogy",
           "title": "Concepts You Already Know",
           "content": {
@@ -1147,7 +1147,7 @@
           }
         },
         {
-          "sort_order": 8,
+          "sort_order": 2,
           "section_type": "prediction",
           "title": "Predict: The Dimension Dilemma",
           "content": {
@@ -1219,7 +1219,7 @@
       "is_published": true,
       "learn_sections": [
         {
-          "sort_order": 1,
+          "sort_order": 3,
           "section_type": "text",
           "title": "Why Regular Databases Cannot Do Similarity Search",
           "content": {
@@ -1227,7 +1227,7 @@
           }
         },
         {
-          "sort_order": 2,
+          "sort_order": 1,
           "section_type": "diagram",
           "title": "Vector Database Architecture",
           "content": {
@@ -1274,7 +1274,7 @@
           }
         },
         {
-          "sort_order": 3,
+          "sort_order": 7,
           "section_type": "comparison",
           "title": "pgvector vs Pinecone vs Qdrant",
           "content": {
@@ -1289,7 +1289,7 @@
           }
         },
         {
-          "sort_order": 4,
+          "sort_order": 8,
           "section_type": "callout",
           "title": "Enterprise Skills Bridge",
           "content": {
@@ -1299,7 +1299,7 @@
           }
         },
         {
-          "sort_order": 5,
+          "sort_order": 6,
           "section_type": "d2_diagram",
           "title": "Vector Search Visualization",
           "content": {
@@ -1309,7 +1309,7 @@
           }
         },
         {
-          "sort_order": 6,
+          "sort_order": 5,
           "section_type": "exploration",
           "title": "Vector Similarity Search — Step by Step",
           "content": {
@@ -1422,7 +1422,7 @@
           }
         },
         {
-          "sort_order": 7,
+          "sort_order": 4,
           "section_type": "analogy",
           "title": "Concepts You Already Know",
           "content": {
@@ -1485,7 +1485,7 @@
           }
         },
         {
-          "sort_order": 8,
+          "sort_order": 2,
           "section_type": "prediction",
           "title": "Predict: The Index Choice",
           "content": {
@@ -1545,7 +1545,7 @@
       "is_published": true,
       "learn_sections": [
         {
-          "sort_order": 1,
+          "sort_order": 3,
           "section_type": "text",
           "title": "Why Dense Search Alone Is Not Enough",
           "content": {
@@ -1553,7 +1553,7 @@
           }
         },
         {
-          "sort_order": 2,
+          "sort_order": 9,
           "section_type": "steps",
           "title": "Hybrid Search Pipeline",
           "content": {
@@ -1578,7 +1578,7 @@
           }
         },
         {
-          "sort_order": 3,
+          "sort_order": 8,
           "section_type": "comparison",
           "title": "Keyword-Only vs Semantic-Only vs Hybrid",
           "content": {
@@ -1593,7 +1593,7 @@
           }
         },
         {
-          "sort_order": 4,
+          "sort_order": 10,
           "section_type": "callout",
           "title": "Production Insight",
           "content": {
@@ -1603,7 +1603,7 @@
           }
         },
         {
-          "sort_order": 5,
+          "sort_order": 1,
           "section_type": "d2_diagram",
           "title": "Production RAG Stack",
           "content": {
@@ -1623,7 +1623,7 @@
           }
         },
         {
-          "sort_order": 7,
+          "sort_order": 5,
           "section_type": "exploration",
           "title": "Hybrid Retrieval — Keyword + Semantic Combined",
           "content": {
@@ -1763,7 +1763,7 @@
           }
         },
         {
-          "sort_order": 8,
+          "sort_order": 4,
           "section_type": "analogy",
           "title": "Concepts You Already Know",
           "content": {
@@ -1826,7 +1826,7 @@
           }
         },
         {
-          "sort_order": 9,
+          "sort_order": 2,
           "section_type": "prediction",
           "title": "Predict: The Keyword Trap",
           "content": {
@@ -1841,7 +1841,7 @@
           }
         },
         {
-          "sort_order": 10,
+          "sort_order": 7,
           "section_type": "prediction",
           "title": "Predict: RRF Parameter Tuning",
           "content": {

--- a/src/app/chapters/[slug]/levels/[levelNum]/page.tsx
+++ b/src/app/chapters/[slug]/levels/[levelNum]/page.tsx
@@ -9,8 +9,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { auth } from "@/lib/auth";
-import LearnPanel from "@/components/learn/LearnPanel";
-import GamePanel from "@/components/games/GamePanel";
+import LevelPageClient from "@/components/level/LevelPageClient";
 import type { LearnSection, GameType, GameConfig } from "@/types/content";
 
 export const dynamic = "force-dynamic";
@@ -191,54 +190,6 @@ function ChevronRight({ className }: { className?: string }) {
   );
 }
 
-// ── Key insight banner ───────────────────────────────────────────────────────
-function KeyInsightBanner({
-  insight,
-}: {
-  insight: string;
-  accentColor: string;
-}) {
-  return (
-    <div
-      className="mt-8 rounded-xl p-5 flex items-start gap-4"
-      style={{
-        backgroundColor: "rgba(255, 184, 0, 0.08)",
-        border: "1px solid rgba(255, 184, 0, 0.20)",
-        borderLeft: "4px solid var(--color-accent-gold)",
-      }}
-    >
-      {/* Lightbulb icon */}
-      <div
-        className="flex items-center justify-center w-9 h-9 rounded-xl flex-shrink-0 text-lg"
-        style={{
-          backgroundColor: "rgba(255, 184, 0, 0.15)",
-          border: "1px solid rgba(255, 184, 0, 0.25)",
-        }}
-        aria-hidden="true"
-      >
-        💡
-      </div>
-      <div>
-        <p
-          className="text-xs font-bold uppercase mb-1.5"
-          style={{
-            color: "var(--color-accent-gold)",
-            letterSpacing: "1.5px",
-          }}
-        >
-          Key Insight
-        </p>
-        <p
-          className="text-sm leading-relaxed font-medium"
-          style={{ color: "var(--color-text-secondary)" }}
-        >
-          {insight}
-        </p>
-      </div>
-    </div>
-  );
-}
-
 // ── Page ─────────────────────────────────────────────────────────────────────
 export default async function LevelPage({
   params,
@@ -264,6 +215,10 @@ export default async function LevelPage({
 
   // Cast DB types to our content types
   const typedLearnSections = learnSections as unknown as LearnSection[];
+  // Sort sections by sortOrder before passing to the client
+  const sortedSections = [...typedLearnSections].sort(
+    (a, b) => a.sortOrder - b.sortOrder,
+  );
   const gameType = level.gameType as GameType;
   const gameConfig = level.gameConfig as unknown as GameConfig;
 
@@ -456,43 +411,22 @@ export default async function LevelPage({
           </div>
         </div>
 
-        {/* Main two-column layout */}
-        <div className="flex flex-col lg:flex-row gap-6 items-start">
-          {/* Learn panel — 60% on desktop */}
-          <div className="w-full lg:w-[60%]">
-            <LearnPanel
-              learnSections={typedLearnSections}
-              accentColor={accentColor}
-              className="min-h-[400px]"
-            />
-          </div>
-
-          {/* Game panel — 40% on desktop, sticky on scroll */}
-          <div className="w-full lg:w-[40%] lg:sticky lg:top-6">
-            <GamePanel
-              gameType={gameType}
-              gameConfig={gameConfig}
-              accentColor={accentColor}
-              levelTitle={level.title}
-              levelId={level.id}
-              chapterId={chapter.id}
-              chapterSlug={slug}
-              xpReward={level.xpReward ?? 100}
-              keyInsight={level.keyInsight ?? null}
-              nextLevelUrl={nextLevelUrl}
-              backUrl={chapterUrl}
-              isAuthenticated={!!session?.user?.id}
-            />
-          </div>
-        </div>
-
-        {/* Key insight */}
-        {level.keyInsight && (
-          <KeyInsightBanner
-            insight={level.keyInsight}
-            accentColor={accentColor}
-          />
-        )}
+        {/* Step-flow layout: sidebar outline + card-by-card content */}
+        <LevelPageClient
+          learnSections={sortedSections}
+          accentColor={accentColor}
+          gameType={gameType}
+          gameConfig={gameConfig}
+          levelTitle={level.title}
+          levelId={level.id}
+          chapterId={chapter.id}
+          chapterSlug={slug}
+          xpReward={level.xpReward ?? 100}
+          keyInsight={level.keyInsight ?? null}
+          nextLevelUrl={nextLevelUrl}
+          backUrl={chapterUrl}
+          isAuthenticated={!!session?.user?.id}
+        />
 
         {/* Level navigation */}
         <nav

--- a/src/components/games/GamePanel.tsx
+++ b/src/components/games/GamePanel.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import type { GameType, GameConfig } from "@/types/content";
+import type {
+  GameType,
+  GameConfig,
+  SpeedQuizConfig,
+  CodeDebuggerConfig,
+  DiagnosisLabConfig,
+  ArchitectureBattleConfig,
+} from "@/types/content";
 import { saveGuestProgress } from "@/lib/guest-progress";
 import LevelComplete from "@/components/hud/LevelComplete";
 
@@ -66,6 +73,48 @@ const GAME_TYPE_ICONS: Record<GameType, string> = {
   ArchitectureBattle: "⚔️",
 };
 
+// ── Question count helper ───────────────────────────────────────────────────
+
+function getQuestionCount(gameType: string, config: GameConfig): number {
+  switch (gameType) {
+    case "SpeedQuiz":
+      return (config as SpeedQuizConfig).questions?.length ?? 0;
+    case "PipelineBuilder":
+      return 1;
+    case "CodeDebugger":
+      return (config as CodeDebuggerConfig).bugs?.length ?? 0;
+    case "ConceptMatcher":
+      return 1;
+    case "ParameterTuner":
+      return 1;
+    case "DiagnosisLab":
+      return (config as DiagnosisLabConfig).cases?.length ?? 0;
+    case "CostOptimizer":
+      return 1;
+    case "ArchitectureBattle":
+      return (config as ArchitectureBattleConfig).battles?.length ?? 0;
+    default:
+      return 0;
+  }
+}
+
+function getEstimatedMinutes(
+  gameType: string,
+  config: GameConfig,
+  timerEnabled: boolean,
+): string {
+  const qCount = getQuestionCount(gameType, config);
+  if (gameType === "SpeedQuiz") {
+    const tpq = (config as SpeedQuizConfig).timePerQuestion ?? 30;
+    // With timer: time-per-question total; without timer: ~20s average to read + answer
+    const secsEach = timerEnabled ? tpq : 20;
+    const totalSecs = qCount * secsEach + qCount * 2; // +2s feedback per question
+    return `~${Math.max(1, Math.round(totalSecs / 60))} min`;
+  }
+  if (qCount <= 1) return "~2 min";
+  return `~${Math.max(1, Math.round((qCount * 25) / 60))} min`;
+}
+
 // ── Game renderer switch ────────────────────────────────────────────────────
 
 interface GameRendererProps {
@@ -73,6 +122,7 @@ interface GameRendererProps {
   gameConfig: GameConfig;
   accentColor: string;
   onComplete: (score: number, maxScore: number) => void;
+  timerEnabled: boolean;
 }
 
 function GameRenderer({
@@ -80,6 +130,7 @@ function GameRenderer({
   gameConfig,
   accentColor,
   onComplete,
+  timerEnabled,
 }: GameRendererProps) {
   const commonProps = { accentColor, onComplete };
 
@@ -88,6 +139,7 @@ function GameRenderer({
       return (
         <SpeedQuiz
           config={gameConfig as import("@/types/content").SpeedQuizConfig}
+          timerEnabled={timerEnabled}
           {...commonProps}
         />
       );
@@ -153,6 +205,8 @@ function GameRenderer({
 
 // ── Main GamePanel ──────────────────────────────────────────────────────────
 
+const TIMER_PREF_KEY = "aiquest_timer_pref";
+
 export default function GamePanel({
   gameType,
   gameConfig,
@@ -171,6 +225,40 @@ export default function GamePanel({
   const label = GAME_TYPE_LABELS[gameType] ?? gameType;
   const description = GAME_TYPE_DESCRIPTIONS[gameType] ?? "";
   const icon = GAME_TYPE_ICONS[gameType] ?? "🎮";
+
+  // Pre-game state
+  const [gameStarted, setGameStarted] = useState(false);
+  const [timerEnabled, setTimerEnabled] = useState(false);
+  const startBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Load saved timer preference on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(TIMER_PREF_KEY);
+      if (saved !== null) setTimerEnabled(saved === "true");
+    } catch {
+      // localStorage may be unavailable (SSR, incognito)
+    }
+  }, []);
+
+  // Persist timer preference on change
+  const handleTimerToggle = (enabled: boolean) => {
+    setTimerEnabled(enabled);
+    try {
+      localStorage.setItem(TIMER_PREF_KEY, String(enabled));
+    } catch {
+      // ignore
+    }
+  };
+
+  // Focus the Start button when the start card becomes visible
+  useEffect(() => {
+    if (!gameStarted) {
+      // Defer one tick so the DOM is ready
+      const id = setTimeout(() => startBtnRef.current?.focus(), 0);
+      return () => clearTimeout(id);
+    }
+  }, [gameStarted]);
 
   const [gameKey, setGameKey] = useState(0);
   const [completed, setCompleted] = useState(false);
@@ -238,10 +326,136 @@ export default function GamePanel({
   const handleRetry = () => {
     setCompleted(false);
     setShowCompletion(false);
+    setGameStarted(false); // Return to start card on retry
     setGameKey((k) => k + 1);
     startTimeRef.current = Date.now();
   };
 
+  const qCount = getQuestionCount(gameType, gameConfig);
+  const estTime = getEstimatedMinutes(gameType, gameConfig, timerEnabled);
+  const timerSeconds =
+    gameType === "SpeedQuiz"
+      ? ((gameConfig as SpeedQuizConfig).timePerQuestion ?? 30)
+      : 0;
+
+  // ── Start Card ─────────────────────────────────────────────────────────────
+  if (!gameStarted) {
+    return (
+      <div
+        className="p-6 flex flex-col gap-5"
+        style={{
+          backgroundColor: "var(--color-bg-card)",
+          border: "1px solid var(--color-border)",
+          borderRadius: "16px",
+          borderTop: `4px solid ${color}`,
+        }}
+      >
+        {/* Icon + game type badge */}
+        <div className="flex items-center gap-3">
+          <div
+            className="w-12 h-12 rounded-xl flex items-center justify-center text-2xl flex-shrink-0"
+            style={{
+              backgroundColor: `${color}18`,
+              border: `1px solid ${color}30`,
+            }}
+          >
+            {icon}
+          </div>
+          <div>
+            <p
+              className="text-xs font-semibold uppercase"
+              style={{ color: color, letterSpacing: "0.08em" }}
+            >
+              {label}
+            </p>
+            <h3
+              className="font-semibold text-base leading-tight mt-0.5"
+              style={{ color: "var(--color-text-primary)" }}
+            >
+              {levelTitle ?? label}
+            </h3>
+          </div>
+        </div>
+
+        {/* Meta: question count + estimated time */}
+        <p
+          id="game-info"
+          className="text-sm"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          {qCount > 0
+            ? `${qCount} question${qCount !== 1 ? "s" : ""}`
+            : "1 challenge"}{" "}
+          &bull; {estTime}
+        </p>
+
+        {/* Start button */}
+        <button
+          ref={startBtnRef}
+          type="button"
+          aria-describedby="game-info"
+          onClick={() => {
+            startTimeRef.current = Date.now();
+            setGameStarted(true);
+          }}
+          className="w-full rounded-xl py-3 px-5 text-sm font-semibold flex items-center justify-center gap-2"
+          style={{
+            backgroundColor: color,
+            color: "#ffffff",
+            border: "none",
+            cursor: "pointer",
+            transition: "filter 150ms ease, transform 80ms ease",
+          }}
+          onMouseEnter={(e) =>
+            ((e.currentTarget as HTMLButtonElement).style.filter =
+              "brightness(1.1)")
+          }
+          onMouseLeave={(e) =>
+            ((e.currentTarget as HTMLButtonElement).style.filter = "")
+          }
+          onMouseDown={(e) =>
+            ((e.currentTarget as HTMLButtonElement).style.transform =
+              "translateY(1px)")
+          }
+          onMouseUp={(e) =>
+            ((e.currentTarget as HTMLButtonElement).style.transform = "")
+          }
+        >
+          Start Challenge
+          <span aria-hidden="true">→</span>
+        </button>
+
+        {/* Timer toggle — only shown for SpeedQuiz */}
+        {gameType === "SpeedQuiz" && timerSeconds > 0 && (
+          <label
+            htmlFor="timer-toggle"
+            className="flex items-center gap-3 cursor-pointer select-none text-sm"
+            style={{ color: "var(--color-text-secondary)" }}
+          >
+            <input
+              id="timer-toggle"
+              type="checkbox"
+              checked={timerEnabled}
+              onChange={(e) => handleTimerToggle(e.target.checked)}
+              className="w-4 h-4 rounded"
+              style={{ accentColor: color, cursor: "pointer" }}
+            />
+            Enable timer ({timerSeconds}s per question)
+          </label>
+        )}
+
+        {/* Tip */}
+        <p
+          className="text-xs leading-relaxed"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          Tip: Complete the learn sections first for the best score.
+        </p>
+      </div>
+    );
+  }
+
+  // ── Active game ─────────────────────────────────────────────────────────────
   return (
     <>
       <div
@@ -305,6 +519,7 @@ export default function GamePanel({
               gameConfig={gameConfig}
               accentColor={color}
               onComplete={handleComplete}
+              timerEnabled={timerEnabled}
             />
           )}
         </div>

--- a/src/components/games/SpeedQuiz.tsx
+++ b/src/components/games/SpeedQuiz.tsx
@@ -7,6 +7,7 @@ interface SpeedQuizProps {
   config: SpeedQuizConfig;
   accentColor: string;
   onComplete: (score: number, maxScore: number) => void;
+  timerEnabled?: boolean;
 }
 
 const OPTION_KEYS = ["A", "B", "C", "D"];
@@ -15,6 +16,7 @@ export default function SpeedQuiz({
   config,
   accentColor,
   onComplete,
+  timerEnabled = true,
 }: SpeedQuizProps) {
   const { questions, timePerQuestion = 30 } = config;
   const [qIdx, setQIdx] = useState(0);
@@ -70,9 +72,10 @@ export default function SpeedQuiz({
     ],
   );
 
-  // Timer
+  // Timer — only runs when timerEnabled is true
   useEffect(() => {
     setTimeLeft(timePerQuestion);
+    if (!timerEnabled) return;
     timerRef.current = setInterval(() => {
       setTimeLeft((t) => {
         if (t <= 0.1) {
@@ -84,7 +87,7 @@ export default function SpeedQuiz({
       });
     }, 100);
     return stopTimer;
-  }, [qIdx, timePerQuestion, stopTimer, handleAnswer]);
+  }, [qIdx, timePerQuestion, stopTimer, handleAnswer, timerEnabled]);
 
   const timerPct = (timeLeft / timePerQuestion) * 100;
   const timerColor =
@@ -100,28 +103,35 @@ export default function SpeedQuiz({
         <span>
           Question {qIdx + 1} of {questions.length}
         </span>
-        <span
-          className="font-mono font-medium"
-          style={{ color: timerColor, transition: "color 0.3s" }}
-        >
-          {Math.ceil(timeLeft)}s
-        </span>
+        {timerEnabled && (
+          <span
+            className="font-mono font-medium"
+            style={{
+              color: timerColor,
+              transition: "color 0.3s ease",
+            }}
+          >
+            {Math.ceil(timeLeft)}s
+          </span>
+        )}
       </div>
 
-      {/* Timer bar */}
-      <div
-        className="h-1 rounded-full overflow-hidden"
-        style={{ backgroundColor: "var(--color-border)" }}
-      >
+      {/* Timer bar — only shown when timer is enabled */}
+      {timerEnabled && (
         <div
-          className="h-full rounded-full"
-          style={{
-            width: `${timerPct}%`,
-            backgroundColor: timerColor,
-            transition: "width 0.1s linear, background-color 0.3s",
-          }}
-        />
-      </div>
+          className="h-1 rounded-full overflow-hidden"
+          style={{ backgroundColor: "var(--color-border)" }}
+        >
+          <div
+            className="h-full rounded-full"
+            style={{
+              width: `${timerPct}%`,
+              backgroundColor: timerColor,
+              transition: "width 0.1s linear, background-color 0.3s ease",
+            }}
+          />
+        </div>
+      )}
 
       {/* Question */}
       <div

--- a/src/components/level/CardFlow.tsx
+++ b/src/components/level/CardFlow.tsx
@@ -1,0 +1,422 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  useCallback,
+  type ReactNode,
+  type KeyboardEvent,
+} from "react";
+import type { LearnSection } from "@/types/content";
+import LearnPanel from "@/components/learn/LearnPanel";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+interface CardFlowProps {
+  learnSections: LearnSection[];
+  accentColor?: string;
+  gameType: string;
+  gameTitle?: string;
+  currentStep: number;
+  onStepChange: (step: number) => void;
+  totalSteps: number;
+  children?: ReactNode;
+}
+
+// ── Navigation button ──────────────────────────────────────────────────────
+interface NavButtonProps {
+  onClick: () => void;
+  disabled: boolean;
+  direction: "back" | "next";
+  label: string;
+  accentColor: string;
+  isPrimary?: boolean;
+}
+
+function NavButton({
+  onClick,
+  disabled,
+  direction,
+  label,
+  accentColor,
+  isPrimary = false,
+}: NavButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
+        padding: "9px 18px",
+        borderRadius: "var(--radius-button)",
+        fontSize: "14px",
+        fontWeight: 500,
+        fontFamily: "var(--font-sans)",
+        cursor: disabled ? "not-allowed" : "pointer",
+        border: isPrimary ? "none" : "1px solid var(--color-border)",
+        backgroundColor: isPrimary ? accentColor : "var(--color-bg-surface)",
+        color: isPrimary
+          ? "#1a1a2e"
+          : disabled
+            ? "var(--color-text-muted)"
+            : "var(--color-text-primary)",
+        opacity: disabled ? 0.4 : 1,
+        transition:
+          "background-color 150ms ease-out, border-color 150ms ease-out, opacity 150ms ease-out",
+      }}
+      onMouseEnter={(e) => {
+        if (!disabled) {
+          const btn = e.currentTarget as HTMLButtonElement;
+          if (isPrimary) {
+            btn.style.filter = "brightness(1.07)";
+          } else {
+            btn.style.borderColor = accentColor;
+            btn.style.color = accentColor;
+          }
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!disabled) {
+          const btn = e.currentTarget as HTMLButtonElement;
+          if (isPrimary) {
+            btn.style.filter = "";
+          } else {
+            btn.style.borderColor = "var(--color-border)";
+            btn.style.color = "var(--color-text-primary)";
+          }
+        }
+      }}
+    >
+      {direction === "back" && (
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M9 2L4 7L9 12"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
+      {label}
+      {direction === "next" && (
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M5 2L10 7L5 12"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+export default function CardFlow({
+  learnSections,
+  accentColor = "var(--chapter-rag)",
+  gameType: _gameType,
+  gameTitle = "Challenge",
+  currentStep,
+  onStepChange,
+  totalSteps,
+  children,
+}: CardFlowProps) {
+  // Sorted sections — same sort order used by LearnPanel internally
+  const sortedSections = [...learnSections].sort(
+    (a, b) => a.sortOrder - b.sortOrder,
+  );
+
+  // Game step index = number of learn sections (0-based)
+  const gameStepIndex = sortedSections.length;
+  const isOnGameStep = currentStep === gameStepIndex;
+  const isOnLastLearnStep = currentStep === gameStepIndex - 1;
+
+  // Ref for the card heading — used to move focus when step changes
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  // Live region ref for announcing step changes
+  const liveRef = useRef<HTMLDivElement>(null);
+
+  // Focus the card heading on step change for keyboard / screen-reader users
+  useEffect(() => {
+    headingRef.current?.focus({ preventScroll: true });
+    // Update live region
+    if (liveRef.current) {
+      liveRef.current.textContent = `Step ${currentStep + 1} of ${totalSteps}`;
+    }
+  }, [currentStep, totalSteps]);
+
+  // Keyboard navigation — Left/Right arrows when no input is focused
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      const tag = (e.target as HTMLElement).tagName.toLowerCase();
+      const isInputFocused =
+        tag === "input" || tag === "textarea" || tag === "select";
+      if (isInputFocused) return;
+
+      if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        if (currentStep < totalSteps - 1) {
+          onStepChange(currentStep + 1);
+        }
+      } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        if (currentStep > 0) {
+          onStepChange(currentStep - 1);
+        }
+      }
+    },
+    [currentStep, totalSteps, onStepChange],
+  );
+
+  // Next button label
+  const nextLabel = isOnLastLearnStep
+    ? "Start Challenge →"
+    : isOnGameStep
+      ? "Challenge"
+      : "Next";
+
+  // Progress percentage for mobile bar
+  const progressPct =
+    totalSteps > 1 ? (currentStep / (totalSteps - 1)) * 100 : 100;
+
+  return (
+    <div
+      id="card-panel"
+      onKeyDown={handleKeyDown}
+      style={{ display: "flex", flexDirection: "column", flex: 1 }}
+    >
+      {/* ── Accessibility: live region for step announcements ── */}
+      <div
+        ref={liveRef}
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: "absolute",
+          width: "1px",
+          height: "1px",
+          overflow: "hidden",
+          clip: "rect(0,0,0,0)",
+          whiteSpace: "nowrap",
+        }}
+      />
+
+      {/* ── Mobile-only top progress bar ── */}
+      <div
+        className="card-flow-mobile-bar"
+        aria-hidden="true"
+        style={{ display: "block" }}
+      >
+        <div
+          style={{
+            height: "3px",
+            width: "100%",
+            backgroundColor: "var(--color-border-subtle)",
+            position: "relative",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              left: 0,
+              top: 0,
+              height: "100%",
+              width: `${progressPct}%`,
+              backgroundColor: accentColor,
+              transition: "width 300ms ease-out",
+            }}
+          />
+        </div>
+        <style>{`
+          @media (min-width: 768px) {
+            .card-flow-mobile-bar {
+              display: none !important;
+            }
+          }
+        `}</style>
+      </div>
+
+      {/* ── Card area ── */}
+      <div style={{ flex: 1, paddingBottom: "8px" }}>
+        {/* Visually hidden heading receives focus on step change */}
+        <h2
+          ref={headingRef}
+          tabIndex={-1}
+          style={{
+            position: "absolute",
+            width: "1px",
+            height: "1px",
+            overflow: "hidden",
+            clip: "rect(0,0,0,0)",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {isOnGameStep
+            ? gameTitle
+            : (sortedSections[currentStep]?.title ?? `Step ${currentStep + 1}`)}
+        </h2>
+
+        {/* Render each learn section card — all in DOM, only active visible */}
+        {sortedSections.map((section, idx) => (
+          <div
+            key={section.id}
+            id={`card-step-${idx}`}
+            role="tabpanel"
+            aria-labelledby={`step-tab-${idx}`}
+            style={{
+              display: currentStep === idx ? "block" : "none",
+              maxWidth: "800px",
+              margin: "0 auto",
+              padding: "24px 16px",
+            }}
+          >
+            <LearnPanel learnSections={[section]} accentColor={accentColor} />
+          </div>
+        ))}
+
+        {/* Game step — rendered as last card */}
+        {children && (
+          <div
+            id={`card-step-${gameStepIndex}`}
+            role="tabpanel"
+            aria-labelledby={`step-tab-${gameStepIndex}`}
+            style={{
+              display: isOnGameStep ? "block" : "none",
+              maxWidth: "800px",
+              margin: "0 auto",
+              padding: "24px 16px",
+            }}
+          >
+            {children}
+          </div>
+        )}
+      </div>
+
+      {/* ── Bottom navigation bar ── */}
+      <div
+        style={{
+          position: "sticky",
+          bottom: 0,
+          zIndex: 10,
+          backgroundColor: "var(--color-bg-surface)",
+          borderTop: "1px solid var(--color-border)",
+          padding: "12px 16px",
+        }}
+      >
+        <div
+          style={{
+            maxWidth: "800px",
+            margin: "0 auto",
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px",
+          }}
+        >
+          {/* Nav controls row */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: "12px",
+            }}
+          >
+            {/* Back button */}
+            <NavButton
+              direction="back"
+              label="Back"
+              disabled={currentStep === 0}
+              accentColor={accentColor}
+              onClick={() => onStepChange(currentStep - 1)}
+            />
+
+            {/* Step counter */}
+            <span
+              style={{
+                fontSize: "13px",
+                fontFamily: "var(--font-sans)",
+                color: "var(--color-text-muted)",
+                whiteSpace: "nowrap",
+              }}
+              aria-label={`Step ${currentStep + 1} of ${totalSteps}`}
+            >
+              <span style={{ color: accentColor, fontWeight: 600 }}>
+                {currentStep + 1}
+              </span>
+              {" of "}
+              {totalSteps}
+            </span>
+
+            {/* Next / Start Challenge button */}
+            <NavButton
+              direction="next"
+              label={nextLabel}
+              disabled={isOnGameStep}
+              accentColor={accentColor}
+              isPrimary={isOnLastLearnStep}
+              onClick={() => {
+                if (!isOnGameStep) {
+                  onStepChange(currentStep + 1);
+                }
+              }}
+            />
+          </div>
+
+          {/* Skip to Challenge link — hidden when already on game step */}
+          {!isOnGameStep && (
+            <div style={{ textAlign: "center" }}>
+              <button
+                type="button"
+                onClick={() => onStepChange(gameStepIndex)}
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  fontSize: "12px",
+                  fontFamily: "var(--font-sans)",
+                  color: accentColor,
+                  opacity: 0.75,
+                  padding: "2px 4px",
+                  borderRadius: "4px",
+                  transition: "opacity 150ms ease-out",
+                  textDecoration: "underline",
+                  textDecorationStyle: "dotted",
+                  textUnderlineOffset: "2px",
+                }}
+                onMouseEnter={(e) => {
+                  (e.currentTarget as HTMLButtonElement).style.opacity = "1";
+                }}
+                onMouseLeave={(e) => {
+                  (e.currentTarget as HTMLButtonElement).style.opacity = "0.75";
+                }}
+                aria-label="Skip all learn sections and go directly to the challenge"
+              >
+                Skip to Challenge →
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/level/LevelPageClient.tsx
+++ b/src/components/level/LevelPageClient.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import type { LearnSection, GameType, GameConfig } from "@/types/content";
+import StepOutline from "@/components/level/StepOutline";
+import CardFlow from "@/components/level/CardFlow";
+import GamePanel from "@/components/games/GamePanel";
+
+// ── Helper: default title per section type ────────────────────────────────────
+function getSectionDefaultTitle(type: string): string {
+  const titles: Record<string, string> = {
+    text: "Deep Dive",
+    diagram: "Pipeline Diagram",
+    d2_diagram: "Architecture Diagram",
+    exploration: "Interactive Exploration",
+    analogy: "You Already Know This",
+    prediction: "What Do You Think?",
+    comparison: "Before & After",
+    callout: "Enterprise Insight",
+    code: "Production Code",
+    steps: "Step by Step",
+    playground: "Interactive Playground",
+  };
+  return titles[type] ?? "Content";
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+export interface LevelPageClientProps {
+  learnSections: LearnSection[];
+  accentColor: string;
+  gameType: GameType;
+  gameConfig: GameConfig;
+  levelTitle: string;
+  levelId: number;
+  chapterId: number;
+  chapterSlug: string;
+  xpReward: number;
+  keyInsight: string | null;
+  nextLevelUrl: string | null;
+  backUrl: string;
+  isAuthenticated: boolean;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+export default function LevelPageClient({
+  learnSections,
+  accentColor,
+  gameType,
+  gameConfig,
+  levelTitle,
+  levelId,
+  chapterId,
+  chapterSlug,
+  xpReward,
+  keyInsight,
+  nextLevelUrl,
+  backUrl,
+  isAuthenticated,
+}: LevelPageClientProps) {
+  const [currentStep, setCurrentStep] = useState(0);
+
+  // totalSteps = all learn sections + 1 game step
+  const totalSteps = learnSections.length + 1;
+
+  // Build sidebar step items from learn sections (already sorted by server)
+  const stepItems = learnSections.map((s, i) => ({
+    type: s.sectionType,
+    title: s.title ?? getSectionDefaultTitle(s.sectionType),
+    index: i,
+  }));
+
+  return (
+    <div style={{ display: "flex", gap: 0, alignItems: "stretch" }}>
+      {/* Desktop sidebar — hidden on mobile via StepOutline's internal media query */}
+      <StepOutline
+        sections={stepItems}
+        currentStep={currentStep}
+        onStepClick={setCurrentStep}
+        gameTitle={levelTitle}
+        accentColor={accentColor}
+      />
+
+      {/* Main content area */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <CardFlow
+          learnSections={learnSections}
+          accentColor={accentColor}
+          gameType={gameType}
+          gameTitle={levelTitle}
+          currentStep={currentStep}
+          onStepChange={setCurrentStep}
+          totalSteps={totalSteps}
+        >
+          <GamePanel
+            gameType={gameType}
+            gameConfig={gameConfig}
+            accentColor={accentColor}
+            levelTitle={levelTitle}
+            levelId={levelId}
+            chapterId={chapterId}
+            chapterSlug={chapterSlug}
+            xpReward={xpReward}
+            keyInsight={keyInsight}
+            nextLevelUrl={nextLevelUrl}
+            backUrl={backUrl}
+            isAuthenticated={isAuthenticated}
+          />
+        </CardFlow>
+      </div>
+    </div>
+  );
+}

--- a/src/components/level/StepOutline.tsx
+++ b/src/components/level/StepOutline.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+
+// ── Icon mapping ───────────────────────────────────────────────────────────
+const SECTION_TYPE_ICONS: Record<string, string> = {
+  text: "📝",
+  diagram: "📊",
+  d2_diagram: "📐",
+  exploration: "🔍",
+  analogy: "💡",
+  prediction: "🎯",
+  comparison: "⚖️",
+  callout: "💼",
+  code: "💻",
+  steps: "📋",
+  playground: "🎮",
+  game: "⚡",
+};
+
+// ── Types ──────────────────────────────────────────────────────────────────
+interface StepItem {
+  type: string;
+  title: string;
+  index: number;
+}
+
+interface StepOutlineProps {
+  sections: StepItem[];
+  currentStep: number;
+  onStepClick: (index: number) => void;
+  gameTitle?: string;
+  accentColor?: string;
+}
+
+// ── Checkmark SVG ──────────────────────────────────────────────────────────
+function CheckIcon({ color }: { color: string }) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+      aria-hidden="true"
+      style={{ flexShrink: 0 }}
+    >
+      <path
+        d="M2 5l2.5 2.5L8 3"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+// ── Step item ─────────────────────────────────────────────────────────────
+interface StepItemProps {
+  item: StepItem;
+  isActive: boolean;
+  isCompleted: boolean;
+  isFuture: boolean;
+  isGame: boolean;
+  totalCount: number;
+  accentColor: string;
+  onClick: () => void;
+}
+
+function StepItemButton({
+  item,
+  isActive,
+  isCompleted,
+  isFuture,
+  isGame,
+  totalCount,
+  accentColor,
+  onClick,
+}: StepItemProps) {
+  const icon = isGame
+    ? SECTION_TYPE_ICONS.game
+    : (SECTION_TYPE_ICONS[item.type] ?? "📄");
+
+  // Truncate long titles for sidebar
+  const displayTitle =
+    item.title.length > 28 ? item.title.slice(0, 26) + "…" : item.title;
+
+  const stepNumber = item.index + 1;
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={isActive}
+      aria-label={`Step ${stepNumber} of ${totalCount}: ${item.title}`}
+      aria-controls="card-panel"
+      id={`step-tab-${item.index}`}
+      onClick={onClick}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "10px",
+        width: "100%",
+        textAlign: "left",
+        padding: "8px 12px",
+        borderRadius: "10px",
+        cursor: "pointer",
+        border: "none",
+        backgroundColor: isActive ? `${accentColor}18` : "transparent",
+        outline: "none",
+        transition:
+          "background-color 150ms ease-out, border-color 150ms ease-out",
+      }}
+      onMouseEnter={(e) => {
+        if (!isActive) {
+          (e.currentTarget as HTMLButtonElement).style.backgroundColor =
+            "var(--color-bg-card)";
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!isActive) {
+          (e.currentTarget as HTMLButtonElement).style.backgroundColor =
+            "transparent";
+        }
+      }}
+    >
+      {/* Step number circle / checkmark */}
+      <div
+        style={{
+          flexShrink: 0,
+          width: "22px",
+          height: "22px",
+          borderRadius: "50%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: "10px",
+          fontWeight: 700,
+          fontFamily: "var(--font-sans)",
+          backgroundColor: isActive
+            ? accentColor
+            : isCompleted
+              ? `${accentColor}20`
+              : "var(--color-bg-card)",
+          color: isActive
+            ? "#1a1a2e"
+            : isCompleted
+              ? accentColor
+              : "var(--color-text-muted)",
+          border: `1.5px solid ${
+            isActive
+              ? accentColor
+              : isCompleted
+                ? `${accentColor}50`
+                : "var(--color-border)"
+          }`,
+          transition:
+            "background-color 150ms ease-out, border-color 150ms ease-out, color 150ms ease-out",
+        }}
+      >
+        {isCompleted && !isActive ? (
+          <CheckIcon color={accentColor} />
+        ) : (
+          stepNumber
+        )}
+      </div>
+
+      {/* Icon + label */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "6px",
+          minWidth: 0,
+        }}
+      >
+        <span
+          style={{
+            fontSize: "13px",
+            lineHeight: 1,
+            flexShrink: 0,
+          }}
+          aria-hidden="true"
+        >
+          {icon}
+        </span>
+        <span
+          style={{
+            fontSize: "12px",
+            lineHeight: 1.35,
+            fontFamily: "var(--font-sans)",
+            fontWeight: isActive ? 600 : isGame ? 600 : 400,
+            color: isActive
+              ? accentColor
+              : isFuture
+                ? "var(--color-text-muted)"
+                : isGame
+                  ? "var(--color-text-primary)"
+                  : "var(--color-text-secondary)",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            transition: "color 150ms ease-out",
+          }}
+        >
+          {displayTitle}
+        </span>
+      </div>
+
+      {/* Active indicator dot */}
+      {isActive && (
+        <div
+          style={{
+            marginLeft: "auto",
+            flexShrink: 0,
+            width: "5px",
+            height: "5px",
+            borderRadius: "50%",
+            backgroundColor: accentColor,
+          }}
+          aria-hidden="true"
+        />
+      )}
+    </button>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+export default function StepOutline({
+  sections,
+  currentStep,
+  onStepClick,
+  gameTitle = "Challenge",
+  accentColor = "var(--chapter-rag)",
+}: StepOutlineProps) {
+  const activeRef = useRef<HTMLDivElement>(null);
+
+  // Scroll active step into view when currentStep changes
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [currentStep]);
+
+  // Combine learn sections + game step
+  const allSteps: StepItem[] = [
+    ...sections,
+    {
+      type: "game",
+      title: gameTitle,
+      index: sections.length,
+    },
+  ];
+
+  const totalCount = allSteps.length;
+
+  return (
+    /* Hidden on mobile — mobile uses the progress bar in CardFlow */
+    <aside
+      aria-label="Level steps"
+      style={{
+        display: "none",
+        // Revealed via media query below (inline styles can't express @media,
+        // so we use a CSS custom-property trick via className + CSS var fallback.
+        // The actual responsive behavior is handled with a data attribute trick below.)
+      }}
+      className="step-outline-sidebar"
+    >
+      <nav
+        role="tablist"
+        aria-label="Level steps"
+        style={{
+          position: "sticky",
+          top: "80px",
+          width: "220px",
+          flexShrink: 0,
+          backgroundColor: "var(--color-bg-surface)",
+          borderRight: "1px solid var(--color-border)",
+          minHeight: "calc(100vh - 80px)",
+          padding: "16px 8px",
+          overflowY: "auto",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            padding: "0 12px 12px",
+            borderBottom: "1px solid var(--color-border-subtle)",
+            marginBottom: "8px",
+          }}
+        >
+          <p
+            style={{
+              fontSize: "10px",
+              fontFamily: "var(--font-sans)",
+              fontWeight: 600,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            In this level
+          </p>
+        </div>
+
+        {/* Step list */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "2px" }}>
+          {allSteps.map((step, idx) => {
+            const isActive = currentStep === step.index;
+            const isCompleted = step.index < currentStep;
+            const isFuture = step.index > currentStep;
+            const isGame = step.type === "game";
+
+            return (
+              <div key={step.index} ref={isActive ? activeRef : undefined}>
+                {/* Divider before game step */}
+                {isGame && (
+                  <div
+                    style={{
+                      margin: "8px 12px",
+                      borderTop: "1px solid var(--color-border-subtle)",
+                    }}
+                    aria-hidden="true"
+                  />
+                )}
+                <StepItemButton
+                  item={step}
+                  isActive={isActive}
+                  isCompleted={isCompleted}
+                  isFuture={isFuture}
+                  isGame={isGame}
+                  totalCount={totalCount}
+                  accentColor={accentColor}
+                  onClick={() => onStepClick(step.index)}
+                />
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Progress summary at bottom */}
+        <div
+          style={{
+            marginTop: "16px",
+            padding: "10px 12px",
+            borderTop: "1px solid var(--color-border-subtle)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: "6px",
+            }}
+          >
+            <span
+              style={{
+                fontSize: "10px",
+                fontFamily: "var(--font-sans)",
+                color: "var(--color-text-muted)",
+              }}
+            >
+              Progress
+            </span>
+            <span
+              style={{
+                fontSize: "10px",
+                fontFamily: "var(--font-sans)",
+                fontWeight: 600,
+                color: accentColor,
+              }}
+            >
+              {Math.min(currentStep, totalCount)}/{totalCount}
+            </span>
+          </div>
+          <div
+            className="progress-bar-container"
+            style={{ height: "4px" }}
+            role="progressbar"
+            aria-valuenow={Math.min(currentStep, totalCount)}
+            aria-valuemin={0}
+            aria-valuemax={totalCount}
+            aria-label="Level progress"
+          >
+            <div
+              className="progress-bar-fill"
+              style={{
+                width: `${(Math.min(currentStep, totalCount) / totalCount) * 100}%`,
+                backgroundColor: accentColor,
+              }}
+            />
+          </div>
+        </div>
+      </nav>
+
+      {/* Inline responsive CSS — renders the sidebar on desktop */}
+      <style>{`
+        @media (min-width: 1024px) {
+          .step-outline-sidebar {
+            display: block !important;
+          }
+        }
+      `}</style>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
Complete level page UX redesign replacing the 60/40 scroll-dump with an evidence-based card flow.

### New Components (3)
- **StepOutline** — labeled sidebar with section icons, progress, ARIA tablist
- **CardFlow** — single card at a time, back/next/skip, keyboard nav, CSS display:none for state preservation
- **LevelPageClient** — client wrapper bridging server data to client components

### Refactored Components (2)
- **GamePanel** — "Start Challenge" button replaces auto-start, timer toggle (off by default), question count + time estimate
- **SpeedQuiz** — timer now conditional on `timerEnabled` prop

### UX Improvements
- One card at a time (not 11 sections in a scroll dump)
- Labeled step outline with section icons (not anonymous dots)
- "Skip to Challenge" link on every card
- "Start Challenge" button with timer toggle
- Predict-Instruct-Predict card ordering (evidence-based)
- Full accessibility: ARIA roles, focus management, keyboard arrows

### Research Sources
Brilliant (interleaved learn-practice), Duolingo (micro-sessions), Codecademy (paned layout),
DataCamp (video-then-code), LeetCode (resizable split), Neetcode (roadmap graph).
6-expert grill panel: UX Designer, Learning Scientist, Frontend Engineer, Senior Engineer,
Mobile UX Expert, Accessibility Expert.

## Stats
7 files changed, +1,250 / -152 lines

## Test plan
- [x] TypeScript compiles clean
- [x] Next.js build succeeds
- [x] All 10 levels return 200
- [ ] Visual verification in browser
- [ ] Mobile responsive check

Generated with Claude Code