### PR TITLE
fix: resolve 6 UX visual bugs from post-polish sprint

### DIFF
--- a/seed/chapter1-rag.json
+++ b/seed/chapter1-rag.json
@@ -140,10 +140,22 @@
               }
             ],
             "edges": [
-              ["query", "embed"],
-              ["embed", "retrieve"],
-              ["retrieve", "augment"],
-              ["augment", "generate"]
+              [
+                "query",
+                "embed"
+              ],
+              [
+                "embed",
+                "retrieve"
+              ],
+              [
+                "retrieve",
+                "augment"
+              ],
+              [
+                "augment",
+                "generate"
+              ]
             ],
             "animate": true,
             "stepThrough": true
@@ -442,7 +454,10 @@
               {
                 "id": "user-query-arch",
                 "type": "concept",
-                "position": { "x": 600, "y": 0 },
+                "position": {
+                  "x": 600,
+                  "y": 0
+                },
                 "data": {
                   "label": "User Query",
                   "icon": "🔍",
@@ -454,7 +469,10 @@
               {
                 "id": "embed-model",
                 "type": "concept",
-                "position": { "x": 600, "y": 130 },
+                "position": {
+                  "x": 600,
+                  "y": 130
+                },
                 "data": {
                   "label": "Embedding Model",
                   "icon": "📐",
@@ -465,7 +483,10 @@
               {
                 "id": "vector-db",
                 "type": "concept",
-                "position": { "x": 600, "y": 260 },
+                "position": {
+                  "x": 600,
+                  "y": 260
+                },
                 "data": {
                   "label": "Vector Database",
                   "icon": "🗄️",
@@ -476,7 +497,10 @@
               {
                 "id": "retrieved-chunks",
                 "type": "concept",
-                "position": { "x": 600, "y": 390 },
+                "position": {
+                  "x": 600,
+                  "y": 390
+                },
                 "data": {
                   "label": "Retrieved Chunks",
                   "icon": "📄",
@@ -487,7 +511,10 @@
               {
                 "id": "prompt-template",
                 "type": "concept",
-                "position": { "x": 300, "y": 440 },
+                "position": {
+                  "x": 300,
+                  "y": 440
+                },
                 "data": {
                   "label": "Prompt Template",
                   "icon": "📝",
@@ -498,7 +525,10 @@
               {
                 "id": "llm",
                 "type": "concept",
-                "position": { "x": 600, "y": 520 },
+                "position": {
+                  "x": 600,
+                  "y": 520
+                },
                 "data": {
                   "label": "LLM (with Context)",
                   "icon": "✨",
@@ -510,7 +540,10 @@
               {
                 "id": "response",
                 "type": "concept",
-                "position": { "x": 600, "y": 650 },
+                "position": {
+                  "x": 600,
+                  "y": 650
+                },
                 "data": {
                   "label": "Response",
                   "icon": "💬",
@@ -522,7 +555,10 @@
               {
                 "id": "raw-docs",
                 "type": "concept",
-                "position": { "x": 0, "y": 0 },
+                "position": {
+                  "x": 0,
+                  "y": 0
+                },
                 "data": {
                   "label": "Raw Documents",
                   "icon": "📚",
@@ -533,7 +569,10 @@
               {
                 "id": "chunking",
                 "type": "concept",
-                "position": { "x": 0, "y": 130 },
+                "position": {
+                  "x": 0,
+                  "y": 130
+                },
                 "data": {
                   "label": "Chunking",
                   "icon": "✂️",
@@ -544,7 +583,10 @@
               {
                 "id": "embed-index",
                 "type": "concept",
-                "position": { "x": 0, "y": 260 },
+                "position": {
+                  "x": 0,
+                  "y": 260
+                },
                 "data": {
                   "label": "Embed & Index",
                   "icon": "⚡",
@@ -629,61 +671,113 @@
               {
                 "id": "root",
                 "type": "decision",
-                "position": { "x": 0, "y": 0 },
-                "data": { "label": "Do you need\nup-to-date knowledge?" }
+                "position": {
+                  "x": 0,
+                  "y": 280
+                },
+                "data": {
+                  "label": "Do you need\nup-to-date knowledge?"
+                }
               },
               {
                 "id": "use-rag",
                 "type": "outcome",
-                "position": { "x": 0, "y": 0 },
-                "data": { "label": "Use RAG", "color": "#3b82f6" }
+                "position": {
+                  "x": 240,
+                  "y": 80
+                },
+                "data": {
+                  "label": "Use RAG",
+                  "color": "#3b82f6"
+                }
               },
               {
                 "id": "enterprise-docs",
                 "type": "decision",
-                "position": { "x": 0, "y": 0 },
-                "data": { "label": "Need enterprise\ndocs?" }
+                "position": {
+                  "x": 480,
+                  "y": 80
+                },
+                "data": {
+                  "label": "Need enterprise\ndocs?"
+                }
               },
               {
                 "id": "rag-vector",
                 "type": "leaf",
-                "position": { "x": 0, "y": 0 },
-                "data": { "label": "RAG + Vector DB", "color": "#3b82f6" }
+                "position": {
+                  "x": 720,
+                  "y": 0
+                },
+                "data": {
+                  "label": "RAG + Vector DB",
+                  "color": "#3b82f6"
+                }
               },
               {
                 "id": "public-knowledge",
                 "type": "decision",
-                "position": { "x": 0, "y": 0 },
-                "data": { "label": "Public knowledge\nonly?" }
+                "position": {
+                  "x": 720,
+                  "y": 160
+                },
+                "data": {
+                  "label": "Public knowledge\nonly?"
+                }
               },
               {
                 "id": "rag-web",
                 "type": "leaf",
-                "position": { "x": 0, "y": 0 },
-                "data": { "label": "RAG + Web Search", "color": "#3b82f6" }
+                "position": {
+                  "x": 960,
+                  "y": 160
+                },
+                "data": {
+                  "label": "RAG + Web Search",
+                  "color": "#3b82f6"
+                }
               },
               {
                 "id": "task-specific",
                 "type": "decision",
-                "position": { "x": 0, "y": 0 },
-                "data": { "label": "Need task-specific\nbehavior?" }
+                "position": {
+                  "x": 240,
+                  "y": 480
+                },
+                "data": {
+                  "label": "Need task-specific\nbehavior?"
+                }
               },
               {
                 "id": "fine-tune",
                 "type": "outcome",
-                "position": { "x": 0, "y": 0 },
-                "data": { "label": "Fine-Tune", "color": "#f59e0b" }
+                "position": {
+                  "x": 480,
+                  "y": 380
+                },
+                "data": {
+                  "label": "Fine-Tune",
+                  "color": "#f59e0b"
+                }
               },
               {
                 "id": "labeled-data",
                 "type": "decision",
-                "position": { "x": 0, "y": 0 },
-                "data": { "label": "Have labeled\ndata?" }
+                "position": {
+                  "x": 720,
+                  "y": 380
+                },
+                "data": {
+                  "label": "Have labeled\ndata?"
+                }
               },
               {
                 "id": "sft",
                 "type": "leaf",
-                "position": { "x": 0, "y": 0 },
+                "position": {
+                  "x": 960,
+                  "y": 280
+                },
                 "data": {
                   "label": "Supervised\nFine-Tuning",
                   "color": "#f59e0b"
@@ -692,19 +786,33 @@
               {
                 "id": "preference-data",
                 "type": "decision",
-                "position": { "x": 0, "y": 0 },
-                "data": { "label": "Have preference\ndata?" }
+                "position": {
+                  "x": 960,
+                  "y": 480
+                },
+                "data": {
+                  "label": "Have preference\ndata?"
+                }
               },
               {
                 "id": "dpo-rlhf",
                 "type": "leaf",
-                "position": { "x": 0, "y": 0 },
-                "data": { "label": "DPO / RLHF", "color": "#f59e0b" }
+                "position": {
+                  "x": 1200,
+                  "y": 480
+                },
+                "data": {
+                  "label": "DPO / RLHF",
+                  "color": "#f59e0b"
+                }
               },
               {
                 "id": "prompt-eng",
                 "type": "leaf",
-                "position": { "x": 0, "y": 0 },
+                "position": {
+                  "x": 480,
+                  "y": 560
+                },
                 "data": {
                   "label": "Use Prompt\nEngineering",
                   "color": "#10b981"
@@ -718,7 +826,10 @@
                 "target": "use-rag",
                 "label": "Yes",
                 "type": "smoothstep",
-                "style": { "stroke": "#3b82f6", "strokeWidth": 2 },
+                "style": {
+                  "stroke": "#3b82f6",
+                  "strokeWidth": 2
+                },
                 "labelStyle": {
                   "fill": "#3b82f6",
                   "fontWeight": 600,
@@ -735,7 +846,10 @@
                 "target": "task-specific",
                 "label": "No",
                 "type": "smoothstep",
-                "style": { "stroke": "#f59e0b", "strokeWidth": 2 },
+                "style": {
+                  "stroke": "#f59e0b",
+                  "strokeWidth": 2
+                },
                 "labelStyle": {
                   "fill": "#f59e0b",
                   "fontWeight": 600,
@@ -751,7 +865,10 @@
                 "source": "use-rag",
                 "target": "enterprise-docs",
                 "type": "smoothstep",
-                "style": { "stroke": "#3b82f6", "strokeWidth": 1.5 }
+                "style": {
+                  "stroke": "#3b82f6",
+                  "strokeWidth": 1.5
+                }
               },
               {
                 "id": "enterprise-yes",
@@ -759,7 +876,10 @@
                 "target": "rag-vector",
                 "label": "Yes",
                 "type": "smoothstep",
-                "style": { "stroke": "#3b82f6", "strokeWidth": 1.5 },
+                "style": {
+                  "stroke": "#3b82f6",
+                  "strokeWidth": 1.5
+                },
                 "labelStyle": {
                   "fill": "#3b82f6",
                   "fontWeight": 600,
@@ -776,7 +896,10 @@
                 "target": "public-knowledge",
                 "label": "No",
                 "type": "smoothstep",
-                "style": { "stroke": "#3b82f6", "strokeWidth": 1.5 },
+                "style": {
+                  "stroke": "#3b82f6",
+                  "strokeWidth": 1.5
+                },
                 "labelStyle": {
                   "fill": "#3b82f6",
                   "fontWeight": 600,
@@ -793,7 +916,10 @@
                 "target": "rag-web",
                 "label": "Yes",
                 "type": "smoothstep",
-                "style": { "stroke": "#3b82f6", "strokeWidth": 1.5 },
+                "style": {
+                  "stroke": "#3b82f6",
+                  "strokeWidth": 1.5
+                },
                 "labelStyle": {
                   "fill": "#3b82f6",
                   "fontWeight": 600,
@@ -810,7 +936,10 @@
                 "target": "fine-tune",
                 "label": "Yes",
                 "type": "smoothstep",
-                "style": { "stroke": "#f59e0b", "strokeWidth": 2 },
+                "style": {
+                  "stroke": "#f59e0b",
+                  "strokeWidth": 2
+                },
                 "labelStyle": {
                   "fill": "#f59e0b",
                   "fontWeight": 600,
@@ -827,7 +956,10 @@
                 "target": "prompt-eng",
                 "label": "No",
                 "type": "smoothstep",
-                "style": { "stroke": "#10b981", "strokeWidth": 2 },
+                "style": {
+                  "stroke": "#10b981",
+                  "strokeWidth": 2
+                },
                 "labelStyle": {
                   "fill": "#10b981",
                   "fontWeight": 600,
@@ -843,7 +975,10 @@
                 "source": "fine-tune",
                 "target": "labeled-data",
                 "type": "smoothstep",
-                "style": { "stroke": "#f59e0b", "strokeWidth": 1.5 }
+                "style": {
+                  "stroke": "#f59e0b",
+                  "strokeWidth": 1.5
+                }
               },
               {
                 "id": "labeled-yes",
@@ -851,7 +986,10 @@
                 "target": "sft",
                 "label": "Yes",
                 "type": "smoothstep",
-                "style": { "stroke": "#f59e0b", "strokeWidth": 1.5 },
+                "style": {
+                  "stroke": "#f59e0b",
+                  "strokeWidth": 1.5
+                },
                 "labelStyle": {
                   "fill": "#f59e0b",
                   "fontWeight": 600,
@@ -868,7 +1006,10 @@
                 "target": "preference-data",
                 "label": "No",
                 "type": "smoothstep",
-                "style": { "stroke": "#f59e0b", "strokeWidth": 1.5 },
+                "style": {
+                  "stroke": "#f59e0b",
+                  "strokeWidth": 1.5
+                },
                 "labelStyle": {
                   "fill": "#f59e0b",
                   "fontWeight": 600,
@@ -885,7 +1026,10 @@
                 "target": "dpo-rlhf",
                 "label": "Yes",
                 "type": "smoothstep",
-                "style": { "stroke": "#f59e0b", "strokeWidth": 1.5 },
+                "style": {
+                  "stroke": "#f59e0b",
+                  "strokeWidth": 1.5
+                },
                 "labelStyle": {
                   "fill": "#f59e0b",
                   "fontWeight": 600,
@@ -1006,15 +1150,31 @@
             "code": "from langchain.text_splitter import RecursiveCharacterTextSplitter\nfrom langchain.document_loaders import UnstructuredPDFLoader\nfrom pathlib import Path\nimport hashlib\n\n# Step 1: Load and parse documents\nloader = UnstructuredPDFLoader(\"contract.pdf\", mode=\"elements\")\ndocuments = loader.load()\n\n# Step 2: Split with RecursiveCharacterTextSplitter\nsplitter = RecursiveCharacterTextSplitter(\n    chunk_size=512,          # tokens, not characters\n    chunk_overlap=50,        # 10% overlap\n    separators=[\"\\n\\n\", \"\\n\", \". \", \" \", \"\"],  # hierarchy\n    length_function=len,\n)\nchunks = splitter.split_documents(documents)\n\n# Step 3: Enrich metadata per chunk\nfor i, chunk in enumerate(chunks):\n    chunk.metadata.update({\n        \"chunk_id\": hashlib.md5(chunk.page_content.encode()).hexdigest()[:8],\n        \"doc_id\": Path(\"contract.pdf\").stem,\n        \"chunk_index\": i,\n        \"section\": chunk.metadata.get(\"category\", \"unknown\"),\n    })\n\nprint(f\"Created {len(chunks)} chunks from {len(documents)} pages\")\n# Typical: 10-page contract → 45-80 chunks at 512 tokens",
             "annotations": [
               {
-                "lines": [6, 7],
+                "lines": [
+                  6,
+                  7
+                ],
                 "text": "UnstructuredPDFLoader with mode='elements' parses headings, paragraphs, tables separately — crucial for structured documents. Raw PDF text extraction produces corrupted chunks."
               },
               {
-                "lines": [10, 11, 12, 13, 14],
+                "lines": [
+                  10,
+                  11,
+                  12,
+                  13,
+                  14
+                ],
                 "text": "chunk_size=512 and chunk_overlap=50 is the FloTorch-validated production default. The separators list defines the fallback hierarchy — try paragraph breaks first, then sentence breaks, then word breaks."
               },
               {
-                "lines": [18, 19, 20, 21, 22, 23],
+                "lines": [
+                  18,
+                  19,
+                  20,
+                  21,
+                  22,
+                  23
+                ],
                 "text": "Chunk-level metadata enables filtered retrieval: 'only search chunks from contracts signed in 2024' or 'only search the indemnification section'. Without metadata, every query searches the entire corpus."
               }
             ]
@@ -1355,15 +1515,23 @@
             "code": "import openai\nimport numpy as np\nfrom typing import List\n\nclient = openai.OpenAI()\n\ndef embed_documents(\n    texts: List[str],\n    model: str = \"text-embedding-3-small\",\n    dimensions: int = 512,  # Matryoshka truncation\n) -> np.ndarray:\n    \"\"\"Embed texts with Matryoshka truncation for cost-efficient storage.\"\"\"\n    response = client.embeddings.create(\n        model=model,\n        input=texts,\n        dimensions=dimensions,  # MRL truncation built into API\n    )\n    vectors = np.array([e.embedding for e in response.data])\n    # Normalize for cosine similarity (pgvector <=>)\n    norms = np.linalg.norm(vectors, axis=1, keepdims=True)\n    return vectors / norms\n\n# Cost comparison:\n# text-embedding-3-small, 512 dims: $0.02/MTok — 98% quality at 25% storage\n# text-embedding-3-large, 1536 dims: $0.13/MTok — marginal quality gain\n# Self-hosted BGE-M3, 512 dims: ~$0/query after $20/mo GPU\nchunks = [\"Document chunk 1...\", \"Document chunk 2...\"]\nvectors = embed_documents(chunks, dimensions=512)\nprint(f\"Shape: {vectors.shape}\")  # (2, 512)",
             "annotations": [
               {
-                "lines": [13],
+                "lines": [
+                  13
+                ],
                 "text": "The 'dimensions' parameter activates Matryoshka truncation built into OpenAI's API. Setting 512 instead of 1536 reduces storage by 67% and cuts vector DB costs proportionally."
               },
               {
-                "lines": [16],
+                "lines": [
+                  16
+                ],
                 "text": "Always normalize embeddings before storing in pgvector. Normalized vectors allow using <=> (cosine distance) which is more semantically accurate than <-> (L2 distance) for text."
               },
               {
-                "lines": [20, 21, 22],
+                "lines": [
+                  20,
+                  21,
+                  22
+                ],
                 "text": "At 10M documents and 500K queries/month: text-embedding-3-small costs ~$200/month. Self-hosted BGE-M3 on a $20/mo GPU instance costs... $20/month. Break-even is around 5K queries/day."
               }
             ]
@@ -1712,10 +1880,22 @@
               }
             ],
             "edges": [
-              ["ingest", "index"],
-              ["index", "store"],
-              ["store", "query"],
-              ["query", "retrieve"]
+              [
+                "ingest",
+                "index"
+              ],
+              [
+                "index",
+                "store"
+              ],
+              [
+                "store",
+                "query"
+              ],
+              [
+                "query",
+                "retrieve"
+              ]
             ],
             "animate": true,
             "stepThrough": true
@@ -2387,11 +2567,26 @@
               }
             ],
             "edges": [
-              ["query", "biencoder"],
-              ["biencoder", "check"],
-              ["check", "crossencoder"],
-              ["check", "llm"],
-              ["crossencoder", "llm"]
+              [
+                "query",
+                "biencoder"
+              ],
+              [
+                "biencoder",
+                "check"
+              ],
+              [
+                "check",
+                "crossencoder"
+              ],
+              [
+                "check",
+                "llm"
+              ],
+              [
+                "crossencoder",
+                "llm"
+              ]
             ],
             "animate": true
           }
@@ -2406,11 +2601,20 @@
             "code": "import cohere\nfrom dataclasses import dataclass\n\nco = cohere.Client(api_key=\"...\")\n\n@dataclass\nclass RetrievedDoc:\n    id: str\n    content: str\n    score: float  # bi-encoder similarity score\n\ndef rerank_with_conditional_skip(\n    query: str,\n    candidates: list[RetrievedDoc],\n    confidence_threshold: float = 0.85,\n    top_n: int = 5,\n) -> list[RetrievedDoc]:\n    # Gate: skip re-ranking if top result is highly confident\n    if candidates[0].score >= confidence_threshold:\n        return candidates[:top_n]  # bi-encoder top-K is sufficient\n    \n    # Cross-encoder re-ranking for ambiguous queries\n    results = co.rerank(\n        model=\"rerank-english-v3.0\",\n        query=query,\n        documents=[c.content for c in candidates],\n        top_n=top_n,\n    )\n    \n    return [\n        candidates[r.index]\n        for r in results.results\n    ]\n\n# Metrics from production:\n# - 63% of queries skip the reranker (confidence > 0.85)\n# - p95 latency: 1.8s → 950ms after conditional skip\n# - Quality maintained: same faithfulness (0.91) on skipped queries",
             "annotations": [
               {
-                "lines": [17, 18],
+                "lines": [
+                  17,
+                  18
+                ],
                 "text": "The conditional gate is the key optimization. When bi-encoder confidence is high (top result score >= 0.85), the ranking is already good enough. The cross-encoder adds 180ms of latency with minimal quality improvement for these queries."
               },
               {
-                "lines": [21, 22, 23, 24, 25],
+                "lines": [
+                  21,
+                  22,
+                  23,
+                  24,
+                  25
+                ],
                 "text": "Cohere Rerank v3 is the production standard: 33% better nDCG@3 than bi-encoder alone. Cohere charges per API call — another reason to use conditional skipping aggressively."
               }
             ]
@@ -2699,11 +2903,19 @@
             "code": "from ragas import evaluate\nfrom ragas.metrics import (\n    faithfulness,\n    answer_relevancy,\n    context_precision,\n    context_recall,\n)\nfrom langchain_anthropic import ChatAnthropic\nfrom datasets import Dataset\nimport pytest\n\n# Use a DIFFERENT model family as judge than your generator\n# Generator: GPT-4o. Judge: Claude Sonnet 3.5\nJUDGE_LLM = ChatAnthropic(model=\"claude-sonnet-4-5\")\n\ndef test_rag_quality_gate(rag_chain, golden_dataset):\n    questions, contexts, answers, ground_truths = golden_dataset\n    \n    eval_data = Dataset.from_dict({\n        \"question\": questions,\n        \"answer\": [rag_chain.invoke(q) for q in questions],\n        \"contexts\": contexts,\n        \"ground_truth\": ground_truths,\n    })\n    \n    result = evaluate(\n        eval_data,\n        metrics=[faithfulness, answer_relevancy, context_precision],\n        llm=JUDGE_LLM,  # Different family eliminates self-grading bias\n    )\n    \n    # Faithfulness first — it's the hallucination gate\n    assert result[\"faithfulness\"] >= 0.80, (\n        f\"DEPLOY BLOCKED: Faithfulness {result['faithfulness']:.2f} < 0.80 minimum. \"\n        f\"This means {(1-result['faithfulness'])*100:.0f}% of answers contain fabricated claims.\"\n    )\n    # Secondary quality gates\n    assert result[\"answer_relevancy\"] >= 0.75\n    assert result[\"context_precision\"] >= 0.60",
             "annotations": [
               {
-                "lines": [13],
+                "lines": [
+                  13
+                ],
                 "text": "Critical: using Claude (Anthropic) to judge outputs from GPT-4o (OpenAI) eliminates same-family bias. Both models are capable judges but have different failure modes — disagreements between them surface real quality issues."
               },
               {
-                "lines": [29, 30, 31, 32, 33],
+                "lines": [
+                  29,
+                  30,
+                  31,
+                  32,
+                  33
+                ],
                 "text": "Faithfulness >= 0.80 is the industry minimum for customer-facing applications. Below 0.80 means more than 1-in-5 answers contain fabricated claims. Express the failure message as a percentage — it makes the severity clear to reviewers."
               }
             ]
@@ -3125,10 +3337,22 @@
               }
             ],
             "edges": [
-              ["corpus", "graphbuild"],
-              ["graphbuild", "query_router"],
-              ["query_router", "graphrag"],
-              ["query_router", "agentic"]
+              [
+                "corpus",
+                "graphbuild"
+              ],
+              [
+                "graphbuild",
+                "query_router"
+              ],
+              [
+                "query_router",
+                "graphrag"
+              ],
+              [
+                "query_router",
+                "agentic"
+              ]
             ],
             "animate": true
           }
@@ -3507,11 +3731,19 @@
             "code": "import redis\nimport numpy as np\nfrom openai import OpenAI\nfrom typing import Optional\n\nclient = OpenAI()\nr = redis.Redis(host=\"localhost\", port=6379, db=0)\n\nSIMILARITY_THRESHOLD = 0.95  # High threshold — only cache near-identical queries\nCACHE_TTL_SECONDS = 3600      # 1 hour — adjust based on knowledge base update frequency\n\ndef semantic_cache_lookup(\n    query: str,\n    query_embedding: np.ndarray,\n    namespace: str = \"rag_cache\",\n) -> Optional[str]:\n    # Check all cached embeddings for similarity\n    cached_keys = r.keys(f\"{namespace}:*\")\n    for key in cached_keys:\n        cached_data = r.hgetall(key)\n        cached_embedding = np.frombuffer(cached_data[b\"embedding\"], dtype=np.float32)\n        similarity = np.dot(query_embedding, cached_embedding)\n        if similarity >= SIMILARITY_THRESHOLD:\n            r.expire(key, CACHE_TTL_SECONDS)  # refresh TTL on cache hit\n            return cached_data[b\"response\"].decode()\n    return None  # cache miss\n\ndef cache_store(query_embedding: np.ndarray, response: str, namespace: str = \"rag_cache\") -> None:\n    key = f\"{namespace}:{hash(response)}\"\n    r.hset(key, mapping={\n        \"embedding\": query_embedding.astype(np.float32).tobytes(),\n        \"response\": response,\n    })\n    r.expire(key, CACHE_TTL_SECONDS)\n\n# Production metrics:\n# - 35% cache hit rate on internal knowledge base queries\n# - $2.50/query → $1.63/query after caching (35% reduction)\n# - p50 latency: 800ms → 12ms on cache hits",
             "annotations": [
               {
-                "lines": [8],
+                "lines": [
+                  8
+                ],
                 "text": "SIMILARITY_THRESHOLD=0.95 is conservative — only serve cached responses for near-identical queries. A threshold of 0.90 would increase hit rate but risk returning the wrong cached answer for subtly different questions."
               },
               {
-                "lines": [18, 19, 20, 21, 22],
+                "lines": [
+                  18,
+                  19,
+                  20,
+                  21,
+                  22
+                ],
                 "text": "For production at scale, replace this linear scan with a vector store (pgvector or Redis Stack with VSS). Linear scan is O(n) over all cached queries — fine for < 10K cached entries, too slow beyond that."
               }
             ]

--- a/seed/patch-decision-tree-positions.ts
+++ b/seed/patch-decision-tree-positions.ts
@@ -1,0 +1,80 @@
+/**
+ * Patch: Fix RAG vs Fine-Tuning Decision Tree node positions.
+ * All nodes were at {x:0, y:0}, causing them to overlap in React Flow.
+ *
+ * Run: tsx seed/patch-decision-tree-positions.ts
+ */
+
+import { Pool } from "pg";
+
+const positions: Record<string, { x: number; y: number }> = {
+  root: { x: 0, y: 280 },
+  "use-rag": { x: 240, y: 80 },
+  "task-specific": { x: 240, y: 480 },
+  "enterprise-docs": { x: 480, y: 80 },
+  "fine-tune": { x: 480, y: 380 },
+  "prompt-eng": { x: 480, y: 560 },
+  "rag-vector": { x: 720, y: 0 },
+  "public-knowledge": { x: 720, y: 160 },
+  "labeled-data": { x: 720, y: 380 },
+  "rag-web": { x: 960, y: 160 },
+  sft: { x: 960, y: 280 },
+  "preference-data": { x: 960, y: 480 },
+  "dpo-rlhf": { x: 1200, y: 480 },
+};
+
+async function main() {
+  const client = new Pool({ connectionString: process.env.DATABASE_URL });
+
+  // Find the decision tree learn section (level 1, sort_order 7)
+  const result = await client.query<{
+    id: number;
+    content: Record<string, unknown>;
+  }>(
+    `SELECT ls.id, ls.content
+     FROM quest_learn_sections ls
+     JOIN quest_levels ql ON ls.level_id = ql.id
+     WHERE ql.slug = 'what-is-rag'
+       AND ls.sort_order = 7
+       AND ls.section_type = 'exploration'
+     LIMIT 1`,
+  );
+
+  if (result.rows.length === 0) {
+    console.error(
+      "Could not find the decision tree section. Ensure the DB is seeded.",
+    );
+    process.exit(1);
+  }
+
+  const row = result.rows[0];
+  const content = row.content as {
+    nodes: Array<{
+      id: string;
+      position: { x: number; y: number };
+      [key: string]: unknown;
+    }>;
+    [key: string]: unknown;
+  };
+
+  let updated = 0;
+  for (const node of content.nodes) {
+    if (node.id in positions) {
+      node.position = positions[node.id];
+      updated++;
+    }
+  }
+
+  await client.query(
+    `UPDATE quest_learn_sections SET content = $1 WHERE id = $2`,
+    [JSON.stringify(content), row.id],
+  );
+
+  console.log(`Updated ${updated} node positions in section id=${row.id}`);
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/learn/ExplorationWrapper.tsx
+++ b/src/components/learn/ExplorationWrapper.tsx
@@ -100,18 +100,21 @@ export default function ExplorationWrapper({
             {title}
           </h3>
         </div>
-        {!isDesktop && (
-          <span
-            className="text-xs px-2 py-1 rounded-lg"
-            style={{
-              backgroundColor: "var(--color-bg-surface)",
-              color: "var(--color-text-muted)",
-              border: "1px solid var(--color-border)",
-            }}
-          >
-            {isTablet ? "Click to explore" : "Swipe through steps"}
-          </span>
-        )}
+        <span
+          className="text-xs px-2 py-1 rounded-lg"
+          style={{
+            backgroundColor: "var(--color-bg-surface)",
+            color: "var(--color-text-muted)",
+            border: "1px solid var(--color-border)",
+            flexShrink: 0,
+          }}
+        >
+          {isDesktop
+            ? "Click any node to see details. Drag to explore. Use +/− to zoom."
+            : isTablet
+              ? "Click to explore"
+              : "Swipe through steps"}
+        </span>
       </div>
 
       {/* Content */}

--- a/src/components/learn/PipelineDiagram.tsx
+++ b/src/components/learn/PipelineDiagram.tsx
@@ -325,7 +325,7 @@ export default function PipelineDiagram({
       {completed ? (
         <div
           className="flex flex-col items-center justify-center gap-4 py-10 px-6 text-center"
-          style={{ backgroundColor: "var(--code-bg)" }}
+          style={{ backgroundColor: "var(--color-bg-card, var(--code-bg))" }}
         >
           <div className="text-4xl" role="img" aria-label="Pipeline complete">
             ✅
@@ -348,14 +348,18 @@ export default function PipelineDiagram({
           {/* SVG canvas */}
           <div
             className="w-full overflow-x-auto"
-            style={{ backgroundColor: "var(--code-bg)" }}
+            style={{ backgroundColor: "var(--color-bg-card, var(--code-bg))" }}
           >
             <svg
               ref={svgRef}
               width={svgWidth}
               height={svgHeight}
               viewBox={`0 0 ${svgWidth} ${svgHeight}`}
-              style={{ minWidth: svgWidth, display: "block" }}
+              style={{
+                minWidth: svgWidth,
+                display: "block",
+                backgroundColor: "var(--color-bg-card, transparent)",
+              }}
               role="img"
               aria-label="Pipeline diagram"
             >

--- a/src/components/learn/ReactFlowExploration.tsx
+++ b/src/components/learn/ReactFlowExploration.tsx
@@ -176,7 +176,26 @@ export default function ReactFlowExploration({
   interactive = true,
 }: ReactFlowExplorationProps) {
   const [nodes, , onNodesChange] = useNodesState(initialNodes);
-  const [edges, , onEdgesChange] = useEdgesState(initialEdges);
+  // Apply default edge styles — ensure edges are visible on both light and dark themes
+  const styledEdges = initialEdges.map((edge) => ({
+    ...edge,
+    style: {
+      stroke: "var(--color-text-muted)",
+      strokeWidth: 1.5,
+      ...edge.style,
+    },
+    labelStyle: {
+      fill: "var(--color-text-secondary)",
+      fontSize: 11,
+      ...edge.labelStyle,
+    },
+    labelBgStyle: {
+      fill: "var(--color-bg-card)",
+      fillOpacity: 0.85,
+      ...edge.labelBgStyle,
+    },
+  }));
+  const [edges, , onEdgesChange] = useEdgesState(styledEdges);
 
   return (
     <ReactFlow
@@ -186,6 +205,7 @@ export default function ReactFlowExploration({
       onEdgesChange={interactive ? onEdgesChange : undefined}
       nodeTypes={nodeTypes}
       fitView
+      fitViewOptions={{ padding: 0.15 }}
       panOnDrag={interactive}
       zoomOnScroll={interactive}
       zoomOnPinch={interactive}
@@ -193,7 +213,7 @@ export default function ReactFlowExploration({
       nodesConnectable={false}
       elementsSelectable={interactive}
       proOptions={{ hideAttribution: true }}
-      style={{ backgroundColor: "var(--color-code-bg)" }}
+      style={{ backgroundColor: "var(--color-bg-card)" }}
     >
       <Background color="var(--color-border)" gap={20} size={1} />
       {interactive && <Controls />}

--- a/src/components/level/CardFlow.tsx
+++ b/src/components/level/CardFlow.tsx
@@ -153,16 +153,29 @@ export default function CardFlow({
   // Ref for the card heading — used to move focus when step changes
   const headingRef = useRef<HTMLHeadingElement>(null);
 
+  // Ref for the card area — used to scroll to top on step change
+  const cardAreaRef = useRef<HTMLDivElement>(null);
+
   // Live region ref for announcing step changes
   const liveRef = useRef<HTMLDivElement>(null);
 
-  // Focus the card heading on step change for keyboard / screen-reader users
+  // Focus the card heading on step change for keyboard / screen-reader users,
+  // and scroll the card area back to the top.
   useEffect(() => {
     headingRef.current?.focus({ preventScroll: true });
     // Update live region
     if (liveRef.current) {
       liveRef.current.textContent = `Step ${currentStep + 1} of ${totalSteps}`;
     }
+    // Scroll card area to top — respect prefers-reduced-motion
+    const prefersReduced =
+      typeof window !== "undefined" && typeof window.matchMedia === "function"
+        ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        : false;
+    cardAreaRef.current?.scrollIntoView({
+      behavior: prefersReduced ? "instant" : "smooth",
+      block: "start",
+    });
   }, [currentStep, totalSteps]);
 
   // Keyboard navigation — Left/Right arrows when no input is focused
@@ -257,7 +270,7 @@ export default function CardFlow({
       </div>
 
       {/* ── Card area ── */}
-      <div style={{ flex: 1, paddingBottom: "8px" }}>
+      <div ref={cardAreaRef} style={{ flex: 1, paddingBottom: "8px" }}>
         {/* Visually hidden heading receives focus on step change */}
         <h2
           ref={headingRef}

--- a/src/components/level/LevelHeader.tsx
+++ b/src/components/level/LevelHeader.tsx
@@ -32,6 +32,9 @@ export default function LevelHeader({
   // Ref to the collapsible area for height animation
   const collapseRef = useRef<HTMLDivElement>(null);
 
+  // Whether there is any collapsible content to show
+  const hasCollapsibleContent = !!(subtitle || hookQuote);
+
   // Drive the height transition via inline style on the ref node.
   // We use maxHeight (not height) so we don't need to measure exact content height.
   useEffect(() => {
@@ -100,69 +103,71 @@ export default function LevelHeader({
             </h1>
           </div>
 
-          {/* Collapsible section: subtitle + hook quote */}
-          <div
-            ref={collapseRef}
-            style={{
-              overflow: "hidden",
-              maxHeight: isExpanded ? "500px" : "0px",
-              opacity: isExpanded ? 1 : 0,
-              transition: "max-height 300ms ease-out, opacity 200ms ease-out",
-            }}
-            aria-hidden={!isExpanded}
-          >
-            {/* Subtitle */}
-            {subtitle && (
-              <p
-                className="text-sm ml-9 mb-2"
-                style={{ color: "var(--color-text-secondary)" }}
-              >
-                {subtitle}
-              </p>
-            )}
-
-            {/* Hook — editorial pull-quote */}
-            {hookQuote && (
-              <blockquote
-                className="ml-9 mt-3 relative pl-12 pt-8 pb-4 pr-4 rounded-r-lg"
-                style={{
-                  borderLeft: `4px solid ${accentColor}`,
-                  backgroundColor: `${accentColor}06`,
-                }}
-              >
-                {/* Large opening quote glyph */}
-                <span
-                  aria-hidden="true"
-                  className="absolute left-3 font-display leading-none select-none"
-                  style={{
-                    fontSize: "80px",
-                    color: "var(--color-accent-gold)",
-                    lineHeight: 1,
-                    top: "-4px",
-                  }}
-                >
-                  &ldquo;
-                </span>
+          {/* Collapsible section: subtitle + hook quote — only rendered if content exists */}
+          {hasCollapsibleContent && (
+            <div
+              ref={collapseRef}
+              style={{
+                overflow: "hidden",
+                maxHeight: isExpanded ? "500px" : "0px",
+                opacity: isExpanded ? 1 : 0,
+                transition: "max-height 300ms ease-out, opacity 200ms ease-out",
+              }}
+              aria-hidden={!isExpanded}
+            >
+              {/* Subtitle */}
+              {subtitle && (
                 <p
-                  className="font-display italic leading-relaxed"
+                  className="text-sm ml-9 mb-2"
+                  style={{ color: "var(--color-text-secondary)" }}
+                >
+                  {subtitle}
+                </p>
+              )}
+
+              {/* Hook — editorial pull-quote */}
+              {hookQuote && (
+                <blockquote
+                  className="ml-9 mt-3 relative pl-12 pt-8 pb-4 pr-4 rounded-r-lg"
                   style={{
-                    color: "var(--color-text-primary)",
-                    fontSize: "clamp(1rem, 2vw, 1.375rem)",
+                    borderLeft: `4px solid ${accentColor}`,
+                    backgroundColor: `${accentColor}06`,
                   }}
                 >
-                  {hookQuote}
-                </p>
-                {chapterTitle && (
-                  <footer
-                    className="mt-2 text-xs"
-                    style={{ color: "var(--color-text-muted)" }}
+                  {/* Large opening quote glyph */}
+                  <span
+                    aria-hidden="true"
+                    className="absolute left-3 font-display leading-none select-none"
+                    style={{
+                      fontSize: "80px",
+                      color: "var(--color-accent-gold)",
+                      lineHeight: 1,
+                      top: "-4px",
+                    }}
                   >
-                    — Level {levelNum} &middot; {chapterTitle}
-                  </footer>
-                )}
-              </blockquote>
-            )}
-          </div>
+                    &ldquo;
+                  </span>
+                  <p
+                    className="font-display italic leading-relaxed"
+                    style={{
+                      color: "var(--color-text-primary)",
+                      fontSize: "clamp(1rem, 2vw, 1.375rem)",
+                    }}
+                  >
+                    {hookQuote}
+                  </p>
+                  {chapterTitle && (
+                    <footer
+                      className="mt-2 text-xs"
+                      style={{ color: "var(--color-text-muted)" }}
+                    >
+                      — Level {levelNum} &middot; {chapterTitle}
+                    </footer>
+                  )}
+                </blockquote>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Meta: XP + time + level counter — always visible */}


### PR DESCRIPTION
## Summary

- **Bug 1 — LevelHeader blank space**: The collapsible section (subtitle + hook quote) was always rendered with `maxHeight: 500px` on step 0 even when both fields are null in DB. Now guarded by `hasCollapsibleContent = !!(subtitle || hookQuote)` — no more empty 500px gap.
- **Bug 2 — No auto-scroll**: Added `cardAreaRef` to the card area container and call `scrollIntoView({ behavior: 'smooth' })` on step change. Respects `prefers-reduced-motion`.
- **Bug 3 — PipelineDiagram dark background**: SVG canvas wrapper and SVG element use `var(--color-bg-card, var(--code-bg))` fallback chain. Also added explicit `backgroundColor` on the SVG element to prevent the SVG default `fill: black` from showing through.
- **Bug 4 — Decision tree nodes at 0,0**: All 13 nodes in the RAG vs Fine-Tuning decision tree had `position: {x:0, y:0}`. Fixed in `seed/chapter1-rag.json` with a proper left-to-right tree layout (6 columns, 240px apart). Added `seed/patch-decision-tree-positions.ts` for a targeted DB update without full re-seed.
- **Bug 5 — Edges invisible**: `ReactFlowExploration` now applies default edge styles using CSS vars (`--color-text-muted`, `--color-bg-card`) before passing to `useEdgesState`, ensuring visibility on both themes. Added `fitViewOptions={{ padding: 0.15 }}` for better framing.
- **Bug 6 — No guidance on desktop**: `ExplorationWrapper` instruction hint now shows on all viewport sizes. Desktop gets "Click any node to see details. Drag to explore. Use +/− to zoom."

## Test plan

- [ ] All 45 existing tests pass (`npm test`)
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit` — pre-existing `.next/` error only)
- [ ] Level 1 step 0: header shows only title/badge row when subtitle/hook not in DB (no blank space)
- [ ] Level 1 step 0: header expands with subtitle + hook when DB fields are populated
- [ ] Clicking Next/Back scrolls card area to top
- [ ] PipelineDiagram renders correct background in both light and dark themes
- [ ] Level 1 step 7 (sort_order=7): run `tsx seed/patch-decision-tree-positions.ts` to update DB, then verify nodes spread correctly in decision tree
- [ ] React Flow edges are visible on both themes
- [ ] Desktop exploration cards show instruction hint in header

## DB Patch Required

After merging, run on VPS:
```bash
DATABASE_URL=... tsx seed/patch-decision-tree-positions.ts
```
This fixes the decision tree node positions in the live DB without touching other data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)