### PR TITLE
fix: dagre auto-layout, pipeline bg, compact header

### DIFF
--- a/src/components/learn/PipelineDiagram.tsx
+++ b/src/components/learn/PipelineDiagram.tsx
@@ -325,7 +325,7 @@ export default function PipelineDiagram({
       {completed ? (
         <div
           className="flex flex-col items-center justify-center gap-4 py-10 px-6 text-center"
-          style={{ backgroundColor: "var(--color-bg-card, var(--code-bg))" }}
+          style={{ backgroundColor: "var(--color-bg-surface)" }}
         >
           <div className="text-4xl" role="img" aria-label="Pipeline complete">
             ✅
@@ -348,7 +348,7 @@ export default function PipelineDiagram({
           {/* SVG canvas */}
           <div
             className="w-full overflow-x-auto"
-            style={{ backgroundColor: "var(--color-bg-card, var(--code-bg))" }}
+            style={{ backgroundColor: "var(--color-bg-surface)" }}
           >
             <svg
               ref={svgRef}

--- a/src/components/learn/ReactFlowExploration.tsx
+++ b/src/components/learn/ReactFlowExploration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import {
   ReactFlow,
   Background,
@@ -11,6 +11,42 @@ import {
   useEdgesState,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import Dagre from "@dagrejs/dagre";
+
+// Node dimension lookup by type for dagre layout
+const NODE_DIMS: Record<string, { w: number; h: number }> = {
+  concept: { w: 180, h: 60 },
+  decision: { w: 160, h: 52 },
+  outcome: { w: 130, h: 44 },
+  leaf: { w: 150, h: 44 },
+};
+
+/**
+ * Apply dagre auto-layout to nodes/edges.
+ * Always runs — overrides any seed positions to guarantee clean layout.
+ */
+function applyDagreLayout(nodes: Node[], edges: Edge[]): Node[] {
+  const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
+  // Use TB (top-bottom) for trees, LR could be used for pipelines
+  g.setGraph({ rankdir: "TB", nodesep: 60, ranksep: 80 });
+
+  nodes.forEach((node) => {
+    const dims = NODE_DIMS[node.type || "concept"] || NODE_DIMS.concept;
+    g.setNode(node.id, { width: dims.w, height: dims.h });
+  });
+  edges.forEach((edge) => g.setEdge(edge.source, edge.target));
+
+  Dagre.layout(g);
+
+  return nodes.map((node) => {
+    const pos = g.node(node.id);
+    const dims = NODE_DIMS[node.type || "concept"] || NODE_DIMS.concept;
+    return {
+      ...node,
+      position: { x: pos.x - dims.w / 2, y: pos.y - dims.h / 2 },
+    };
+  });
+}
 
 // Custom node component
 function ConceptNode({ data }: { data: Record<string, unknown> }) {
@@ -175,7 +211,12 @@ export default function ReactFlowExploration({
   edges: initialEdges,
   interactive = true,
 }: ReactFlowExplorationProps) {
-  const [nodes, , onNodesChange] = useNodesState(initialNodes);
+  // Always apply dagre layout — seed positions are unreliable
+  const layoutedNodes = useMemo(
+    () => applyDagreLayout(initialNodes, initialEdges),
+    [initialNodes, initialEdges],
+  );
+  const [nodes, , onNodesChange] = useNodesState(layoutedNodes);
   // Apply default edge styles — ensure edges are visible on both light and dark themes
   const styledEdges = initialEdges.map((edge) => ({
     ...edge,

--- a/src/components/level/LevelHeader.tsx
+++ b/src/components/level/LevelHeader.tsx
@@ -56,6 +56,46 @@ export default function LevelHeader({
     el.style.opacity = isExpanded ? "1" : "0";
   }, [isExpanded]);
 
+  // On step > 0, show only a minimal compact bar instead of the full header card
+  if (!isExpanded) {
+    return (
+      <div
+        className="flex items-center gap-2 px-4 py-2 mb-3 rounded-lg"
+        style={{
+          backgroundColor: "var(--color-bg-surface)",
+          borderLeft: `3px solid ${accentColor}`,
+        }}
+      >
+        <span
+          className="inline-flex items-center justify-center w-6 h-6 rounded text-xs font-bold flex-shrink-0"
+          style={{
+            backgroundColor: `${accentColor}20`,
+            color: accentColor,
+          }}
+        >
+          {levelNum}
+        </span>
+        <span
+          className="text-sm font-medium truncate"
+          style={{ color: "var(--color-text-primary)" }}
+        >
+          {title}
+        </span>
+        {xpReward && (
+          <span
+            className="ml-auto text-xs font-bold px-1.5 py-0.5 rounded"
+            style={{
+              color: "var(--color-accent-gold)",
+              backgroundColor: "rgba(245, 158, 11, 0.10)",
+            }}
+          >
+            +{xpReward} XP
+          </span>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div
       className="relative overflow-hidden rounded-2xl p-5 mb-6"

--- a/src/test/unit/LevelHeader.test.tsx
+++ b/src/test/unit/LevelHeader.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import LevelHeader from "@/components/level/LevelHeader";
 
 const baseProps = {
@@ -15,91 +15,42 @@ const baseProps = {
 };
 
 describe("LevelHeader", () => {
-  it("(a) step=0 — collapsible section is visible (maxHeight not 0, opacity not 0)", () => {
+  it("(a) step=0 — full header with hook quote visible", () => {
     render(<LevelHeader {...baseProps} currentStep={0} />);
-
-    // The collapsible wrapper has aria-hidden=false at step 0
-    const collapseWrapper = screen
-      .getByText(baseProps.hookQuote!)
-      .closest("[aria-hidden]");
-    expect(collapseWrapper).not.toBeNull();
-    expect(collapseWrapper).toHaveAttribute("aria-hidden", "false");
-
-    // Hook quote text is in the document
     expect(screen.getByText(baseProps.hookQuote!)).toBeInTheDocument();
-
-    // Subtitle is visible
     expect(screen.getByText(baseProps.subtitle!)).toBeInTheDocument();
-  });
-
-  it("(b) step=1 — collapsible section is collapsed (aria-hidden=true, maxHeight=0px)", () => {
-    render(<LevelHeader {...baseProps} currentStep={1} />);
-
-    // The wrapper should be aria-hidden
-    const collapseWrapper = screen
-      .getByText(baseProps.hookQuote!)
-      .closest("[aria-hidden]");
-    expect(collapseWrapper).not.toBeNull();
-    expect(collapseWrapper).toHaveAttribute("aria-hidden", "true");
-
-    // Inline style should have maxHeight: 0px and opacity: 0
-    const el = collapseWrapper as HTMLElement;
-    expect(el.style.maxHeight).toBe("0px");
-    expect(el.style.opacity).toBe("0");
-  });
-
-  it("(c) prefers-reduced-motion — transition is removed when media query matches", () => {
-    // Mock matchMedia to return prefers-reduced-motion: reduce
-    const mockMatchMedia = vi.fn().mockReturnValue({
-      matches: true,
-      media: "(prefers-reduced-motion: reduce)",
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    });
-    Object.defineProperty(window, "matchMedia", {
-      writable: true,
-      value: mockMatchMedia,
-    });
-
-    render(<LevelHeader {...baseProps} currentStep={1} />);
-
-    const collapseWrapper = screen
-      .getByText(baseProps.hookQuote!)
-      .closest("[aria-hidden]") as HTMLElement;
-
-    // With reduced motion, useEffect sets transition to 'none'
-    // The initial inline style from JSX still sets the correct maxHeight/opacity
-    expect(collapseWrapper.style.maxHeight).toBe("0px");
-    expect(collapseWrapper.style.opacity).toBe("0");
-
-    // Restore
-    Object.defineProperty(window, "matchMedia", {
-      writable: true,
-      value: undefined,
-    });
-  });
-
-  it("(d) title is always visible regardless of step", () => {
-    const { rerender } = render(<LevelHeader {...baseProps} currentStep={0} />);
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
       baseProps.title,
     );
+  });
+
+  it("(b) step=1 — compact bar, no hook quote", () => {
+    render(<LevelHeader {...baseProps} currentStep={1} />);
+    // Hook quote should NOT be in the document (compact mode)
+    expect(screen.queryByText(baseProps.hookQuote!)).toBeNull();
+    // Title should still be visible in compact bar
+    expect(screen.getByText(baseProps.title)).toBeInTheDocument();
+  });
+
+  it("(c) title visible on both step 0 and step 3", () => {
+    const { rerender } = render(<LevelHeader {...baseProps} currentStep={0} />);
+    expect(screen.getByText(baseProps.title)).toBeInTheDocument();
 
     rerender(<LevelHeader {...baseProps} currentStep={3} />);
-    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
-      baseProps.title,
-    );
+    expect(screen.getByText(baseProps.title)).toBeInTheDocument();
   });
 
-  it("(e) XP badge and level counter are always visible", () => {
+  it("(d) XP badge visible on step 0 (full header)", () => {
+    render(<LevelHeader {...baseProps} currentStep={0} />);
+    expect(screen.getByText(`+${baseProps.xpReward} XP`)).toBeInTheDocument();
+  });
+
+  it("(e) XP badge visible on step > 0 (compact bar)", () => {
     render(<LevelHeader {...baseProps} currentStep={2} />);
     expect(screen.getByText(`+${baseProps.xpReward} XP`)).toBeInTheDocument();
-    expect(
-      screen.getByText(`${baseProps.levelNum} / ${baseProps.totalLevels}`),
-    ).toBeInTheDocument();
   });
 
-  it("(f) renders without hookQuote — no blockquote rendered", () => {
+  it("(f) renders without hookQuote — no blockquote", () => {
     render(<LevelHeader {...baseProps} hookQuote={null} currentStep={0} />);
     expect(screen.queryByRole("blockquote")).toBeNull();
   });


### PR DESCRIPTION
## Summary
- ReactFlowExploration now runs dagre layout on ALL nodes — fixes overlapping/scattered nodes on steps 5, 6, 7
- Pipeline diagram background uses `var(--color-bg-surface)` — fixes black background in light mode
- LevelHeader step > 0 shows compact bar instead of full card with blank space

## Root causes
- Nodes had bad positions in seed data; component trusted positions blindly
- `var(--code-bg)` fallback = `#1a1330` (dark) fired in light theme
- Header collapsed subtitle/quote but kept full card padding/gradient = wasted space

🤖 Generated with [Claude Code](https://claude.com/claude-code)