### PR TITLE
fix: gitignore test-results directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+test-results/


### PR DESCRIPTION
Adds test-results/ to .gitignore — Playwright artifacts shouldn't be tracked.